### PR TITLE
Add Implementations to repo list

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,18 @@ There are a variety of systems that use merkle-tree and hash-chain inspired data
 
 In short: JSON documents with named merkle-links that can be traversed.
 
+## Table of Contents
+
+- [Repositories](#repositories)
+  - [Specifications](#specifications)
+  - [Implementations](#implementations)
+    - [New implementations](#new-implementations)
+  - [Other Tools](#other-tools)
+  - [Meta repos](#meta-repos)
+- [Lead](#lead)
+- [Contribute](#contribute)
+- [License](#license)
+
 ## Repositories
 
 IPLD is a multifaceted, distributed effort.

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ IPLD is a multifaceted, distributed effort.
 - [**Go:** ipfs/go-ipld](https://github.com/ipfs/go-ipld) - The Go implementation of IPLD.
 - [**C:** kenCode-de/c-ipld](https://github.com/kenCode-de/c-ipld) - Implementation of the IPLD spec in C.
 
-** New implementations**
+#### New implementations
 
 Are you working on your own implementation in another language? [Open an issue](https://github.com/ipld/ipld/issues) in this repository to discuss it with others, find help, and coordinate efforts. Eventually, we can move it to the organization if you like, add it above, and mention it on the website.
 

--- a/README.md
+++ b/README.md
@@ -23,17 +23,34 @@ In short: JSON documents with named merkle-links that can be traversed.
 
 ## Repositories
 
-IPLD is a multifaceted, distributed effort. Here are our current repositories:
+IPLD is a multifaceted, distributed effort.
 
+### Specifications
+
+- [specs](https://github.com/ipld/specs) - The specifications for IPLD
 - [cid](https://github.com/ipld/cid) - Self-describing content-addressed identifiers for distributed systems
+
+### Implementations
+
+- [**JavaScript:** js-ipld-dag-cbor](https://github.com/ipld/js-ipld-dag-cbor) - JavaScript implementation of the IPLD spec.
+- [**Go:** ipfs/go-ipld](https://github.com/ipfs/go-ipld) - The Go implementation of IPLD.
+- [**C:** kenCode-de/c-ipld](https://github.com/kenCode-de/c-ipld) - Implementation of the IPLD spec in C.
+
+** New implementations**
+
+Are you working on your own implementation in another language? [Open an issue](https://github.com/ipld/ipld/issues) in this repository to discuss it with others, find help, and coordinate efforts. Eventually, we can move it to the organization if you like, add it above, and mention it on the website.
+
+### Other Tools
+
 - [interface-ipld-format](https://github.com/ipld/interface-ipld-format) - A interface you can follow to implement a valid IPLD format, resolvable through the IPLD Resolver (available in IPFS)
-- [ipld](https://github.com/ipld/ipld) - This repo
 - [js-ipld-cli](https://github.com/ipld/js-ipld-cli) - Interact with IPLD on the command line
-- [js-ipld-dag-cbor](https://github.com/ipld/js-ipld-dag-cbor) - JavaScript implementation of the IPLD spec.
 - [js-ipld-dag-pb](https://github.com/ipld/js-ipld-dag-pb) - JavaScript Implementation of the MerkleDAG Nodes with Protobuf.
 - [js-ipld-eth-block](https://github.com/ipld/js-ipld-eth-block) - JavaScript Implementation of the IPLD format - Ethereum Block
 - [js-ipld-resolver](https://github.com/ipld/js-ipld-resolver) - JavaScript implementation of the IPLDService
-- [specs](https://github.com/ipld/specs) - The specifications for IPLD
+
+### Meta repos
+
+- [ipld](https://github.com/ipld/ipld) - This repo, which is now self-describing.
 - [website](https://github.com/ipld/website) - The official website for IPLD, at ipld.io
 
 ## Lead

--- a/README.md
+++ b/README.md
@@ -44,8 +44,29 @@ IPLD is a multifaceted, distributed effort.
 
 ### Implementations
 
-- [**JavaScript:** js-ipld-dag-cbor](https://github.com/ipld/js-ipld-dag-cbor) - JavaScript implementation of the IPLD spec.
-- [**Go:** ipfs/go-ipld](https://github.com/ipfs/go-ipld) - The Go implementation of IPLD.
+IPLD has multiple types of implementations, some of which have been written in multiple languages.
+
+#### Data format description
+
+- [js-ipld-dag-cbor](https://github.com/ipld/js-ipld-dag-cbor) - JavaScript implementation of the IPLD spec.
+- [js-ipld-dag-pb](https://github.com/ipld/js-ipld-dag-pb) - JavaScript Implementation of the MerkleDAG Nodes with Protobuf.
+- [js-ipld-eth-block](https://github.com/ipld/js-ipld-eth-block) - JavaScript Implementation of the IPLD format - Ethereum Block
+- [go-ipld-btc](https://github.com/ipfs/go-ipld-btc)
+- [go-ipld-zcash](https://github.com/ipfs/go-ipld-zcash)
+- [go-ipld-cbor](https://github.com/ipfs/go-ipld-cbor)
+- [go-ipld-git](https://github.com/ipfs/go-ipld-git)
+- [go-ipld-node](https://github.com/ipfs/go-ipld-node)
+
+#### Interface definitin
+- [interface-ipld-format](https://github.com/ipld/interface-ipld-format) - A interface you can follow to implement a valid IPLD format, resolvable through the IPLD Resolver (available in IPFS)
+
+#### Path Resolution
+
+- [js-ipld-resolver](https://github.com/ipld/js-ipld-resolver) - JavaScript implementation of the IPLDService
+
+#### Other repositories
+
+- [**Go:** ipfs/go-ipld](https://github.com/ipfs/go-ipld) - The Go implementation of IPLD (deprecated).
 - [**C:** kenCode-de/c-ipld](https://github.com/kenCode-de/c-ipld) - Implementation of the IPLD spec in C.
 
 #### New implementations
@@ -54,11 +75,7 @@ Are you working on your own implementation in another language? [Open an issue](
 
 ### Other Tools
 
-- [interface-ipld-format](https://github.com/ipld/interface-ipld-format) - A interface you can follow to implement a valid IPLD format, resolvable through the IPLD Resolver (available in IPFS)
 - [js-ipld-cli](https://github.com/ipld/js-ipld-cli) - Interact with IPLD on the command line
-- [js-ipld-dag-pb](https://github.com/ipld/js-ipld-dag-pb) - JavaScript Implementation of the MerkleDAG Nodes with Protobuf.
-- [js-ipld-eth-block](https://github.com/ipld/js-ipld-eth-block) - JavaScript Implementation of the IPLD format - Ethereum Block
-- [js-ipld-resolver](https://github.com/ipld/js-ipld-resolver) - JavaScript implementation of the IPLDService
 
 ### Meta repos
 

--- a/README.md
+++ b/README.md
@@ -79,4 +79,4 @@ Small note: If editing the README, please conform to the [standard-readme](https
 
 ## License
 
-This repository is mainly documents. All of these are licensed under the [CC-BY-SA 3.0](https://ipfs.io/ipfs/QmVreNvKsQmQZ83T86cWSjPu2vR3yZHGPm5jnxFuunEB9u) license, copyright Protocol Labs Inc.
+This repository is mainly documents. All of these are licensed under a [CC-BY-SA 3.0](https://ipfs.io/ipfs/QmVreNvKsQmQZ83T86cWSjPu2vR3yZHGPm5jnxFuunEB9u) license, © 2016 Protocol Labs Inc.


### PR DESCRIPTION
Basically, I divided up the Repositories list to be more useful, mentioned current implementations, and added in a note about how to go about making new ones. This should close both #7 and #9.