### PR TITLE
document the proper use of code coverage tools

### DIFF
--- a/best-practices/go-ci.md
+++ b/best-practices/go-ci.md
@@ -27,6 +27,23 @@ should also run on 1.15.x. Note that upstream Go supports
 [two major releases](https://github.com/golang/go/wiki/Go-Release-Cycle#release-maintenance)
 at once as well.
 
+### Using Code Coverage Tools
+
+Code coverage can be determined in CI, but should not be used as an automatic status checks.
+
+When using Codecov, this can be achieved by using the following `codecov.yml`:
+
+```yml
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+```
+
 #### How to use this document at Protocol Labs
 
 Marten Seemann and the IPLD team have set up [a template repository](https://github.com/ipld/.github)


### PR DESCRIPTION
While code coverage tools are a valuable tool during development, having code coverage aggressively enforced in CI is not a good idea: Removing a bunch of well-tested, but ultimately unnecessary code from a project would be regarded as an improvement by all developers, however, a code coverage tool would only see a drop in coverage and fail the status check on the PR.

We can use "non-blocking status checks" config from the Codecov manual: https://docs.codecov.io/docs/common-recipe-list#set-non-blocking-status-checks.

What we want the code coverage tool to do is report the changes, but to not affect the PR status. See here for a real-world example how this will look like: https://github.com/marten-seemann/codecov-test/pull/5