### PR TITLE
disable Codecov code coverage comments on PR

### DIFF
--- a/best-practices/go-ci.md
+++ b/best-practices/go-ci.md
@@ -34,6 +34,7 @@ Code coverage can be determined in CI, but should not be used as an automatic st
 When using Codecov, this can be achieved by using the following `codecov.yml`:
 
 ```yml
+comment: false
 coverage:
   status:
     project:


### PR DESCRIPTION
Having Codecov comment on every PR is incredibly noise. I had assumed that the previous config we had here already prevented it from doing so, but apparently it doesn't.

cc @mvdan 