### PR TITLE
data-structures: update filecoin's HAMT version

### DIFF
--- a/specs/advanced-data-layouts/hamt/spec.md
+++ b/specs/advanced-data-layouts/hamt/spec.md
@@ -46,7 +46,7 @@ The IPLD HashMap is constructed as a [hash array mapped trie (HAMT)](https://en.
 * Peergos [CHAMP](https://github.com/Peergos/Peergos/blob/master/src/peergos/shared/hamt/Champ.java) implementation
 * [IAMap](https://github.com/rvagg/iamap) JavaScript implementation of the algorithm
 * [ipld-hashmap](https://github.com/rvagg/js-ipld-hashmap) JavaScript IPLD frontend to IAMap with a mutable API
-* [go-hamt-ipld](https://github.com/ipfs/go-hamt-ipld) Filecoin Go HAMT implementation used by the [Lotus](https://lotu.sh/) client. See the appendix for how this implementation differs from this specification.
+* [go-hamt-ipld](https://github.com/filecoin-project/go-hamt-ipld) Filecoin Go HAMT implementation used by the [Lotus](https://lotu.sh/) client. See the appendix for how this implementation differs from this specification.
 
 ## Summary
 
@@ -287,7 +287,7 @@ It encodes directly as [DAG-CBOR](/specs/codecs/dag-cbor/) but uses a different 
 This section documents the specific ways that the Filecoin HAMT variant differs from this specification.
 IPLD HashMap implementations may be able to implement a form that provides compatibility with Filecoin when requested by the user.
 
-The reference Go implementation for the Filecoin HAMT is used by the [Lotus](https://lotu.sh/) client and is available at <https://github.com/ipfs/go-hamt-ipld>.
+The reference Go implementation for the Filecoin HAMT is used by the [Lotus](https://lotu.sh/) client and is available at <https://github.com/filecoin-project/go-hamt-ipld>. Note that this document reflects v3 of the Go module, whose latest version is `v3.0.1` at the time of writing.
 
 ### Implicit and fixed parameters
 

--- a/specs/advanced-data-layouts/hamt/spec.md
+++ b/specs/advanced-data-layouts/hamt/spec.md
@@ -306,9 +306,9 @@ Rather than encoding the HAMT node's `map` field as the full sequence of byte-to
 
 ### Block layout
 
-The IPLD schema describing the Filecoin HAMT varies from the IPLD HashMap [schema](#Schema) and also between version of the Filecoin Actors, so any implementation needing to read Filecoin HAMT blocks will need to handle its specific layout (both layouts if historical data is important to create / read).
+The IPLD schema describing the Filecoin HAMT varies from the IPLD HashMap [schema](#Schema) and also between versions of the Filecoin Actors, so any implementation needing to read Filecoin HAMT blocks will need to handle its specific layout (both layouts if historical data is important to create / read).
 
-The **v3** form of the Filecoin HAMT has the same IPLD layout as the IPLD HashMap except for the lack of an explicit root node to describe the parameters. A Filecoin HAMT's root is the equivalent of `HashMapNode`, which is the same as all other nodes and parameters are implicit.
+The **v3** form of the Filecoin HAMT has the same [substrate](/glossary/#substrate) Data Model layout as the IPLD HashMap except for the lack of an explicit root node to describe the parameters. A Filecoin HAMT's root is the equivalent of `HashMapNode`—the root node is the same as all other nodes, and rather than parameters being explicit, the parameters are implicit and must be derived from the ambient Filecoin chain version.
 
 Both forms of the block layout are presented in the schema below. The difference in block layout is that versions **0.9** to **2** use a keyed union for the `Element` struct (called "Pointer" in Filecoin) whereas version **3** and later use a kinded union. `FilecoinHAMTNodeV0` and `FilecoinHAMTNodeV3` are presented below as the equivalent of `HashMapNode` in the IPLD HashMap for the different versions. There is no equivalent of `HashMapRoot`.
 


### PR DESCRIPTION
This took a bit of work, but it's got the 3 commits from https://github.com/ipld/specs/pull/359, which have mostly been approved. I wouldn't mind a quick eye over the schema at the bottom which the last commit merged from two separate schemas. Is this readable enough or should I back that commit out?

I'll add a tombstone to specs for this file once this is merged.