### PR TITLE
feat: allow inline link definitions for kinded unions

### DIFF
--- a/specs/schemas/schema-schema.ipldsch
+++ b/specs/schemas/schema-schema.ipldsch
@@ -378,7 +378,15 @@ type UnionRepresentation union {
 ##
 ## The referenced type must of course produce the RepresentationKind it's
 ## matched with!
-type UnionRepresentation_Kinded {RepresentationKind:TypeName}
+type UnionRepresentation_Kinded {RepresentationKind:KindedType}
+
+## "KindedType" is used to allow inline link definitions within a kinded union
+## as a shorthand rather than requiring all links be defined as a separate type
+## before used within a kinded union.
+type KindedType union {
+  | TypeName "string"
+  | TypeLink "link"
+} representation kinded
 
 ## "Keyed" union representations will encode as a map, where the map has
 ## exactly one entry, the key string of which will be used to look up the name

--- a/specs/schemas/schema-schema.ipldsch
+++ b/specs/schemas/schema-schema.ipldsch
@@ -385,7 +385,7 @@ type UnionRepresentation_Kinded {RepresentationKind:TypeNameOrLink}
 ## before used within a kinded union.
 type TypeNameOrLink union {
   | TypeName string
-  | TypeLink link
+  | TypeLink map
 } representation kinded
 
 ## "Keyed" union representations will encode as a map, where the map has

--- a/specs/schemas/schema-schema.ipldsch
+++ b/specs/schemas/schema-schema.ipldsch
@@ -526,7 +526,9 @@ type TypeTerm union {
 
 ## InlineDefn represents a declaration of an anonymous type of one of the simple
 ## recursive kinds (e.g. map or list) which is found "inline" in another type's
-## definition.  It's the more complex option of the TypeTerm union.
+## definition.  It is also used to support expressive link declaration in
+## certain places so they don't have to be declared as their own types.
+## InlineDefn is the more complex option of the TypeTerm union.
 ##
 ## Note that the representation of this union -- `representation inline "kind"`
 ## -- as well as the keywords for its members -- align exactly with those
@@ -539,6 +541,7 @@ type TypeTerm union {
 type InlineDefn union {
 	| TypeMap "map"
 	| TypeList "list"
+	| TypeLink "link"
 } representation inline {
 	discriminantKey "kind"
 }

--- a/specs/schemas/schema-schema.ipldsch
+++ b/specs/schemas/schema-schema.ipldsch
@@ -378,14 +378,14 @@ type UnionRepresentation union {
 ##
 ## The referenced type must of course produce the RepresentationKind it's
 ## matched with!
-type UnionRepresentation_Kinded {RepresentationKind:KindedType}
+type UnionRepresentation_Kinded {RepresentationKind:TypeNameOrLink}
 
-## "KindedType" is used to allow inline link definitions within a kinded union
+## "TypeNameOrLink" is used to allow inline link definitions within a kinded union
 ## as a shorthand rather than requiring all links be defined as a separate type
 ## before used within a kinded union.
-type KindedType union {
-  | TypeName "string"
-  | TypeLink "link"
+type TypeNameOrLink union {
+  | TypeName string
+  | TypeLink link
 } representation kinded
 
 ## "Keyed" union representations will encode as a map, where the map has

--- a/specs/schemas/schema-schema.ipldsch.json
+++ b/specs/schemas/schema-schema.ipldsch.json
@@ -308,7 +308,16 @@
 		"UnionRepresentation_Kinded": {
 			"kind": "map",
 			"keyType": "RepresentationKind",
-			"valueType": "TypeName"
+			"valueType": "KindedType"
+		},
+		"KindedType": {
+			"kind": "union",
+			"representation": {
+				"kinded": {
+					"string": "TypeName",
+					"link": "TypeLink"
+				}
+			}
 		},
 		"UnionRepresentation_Keyed": {
 			"kind": "map",

--- a/specs/schemas/schema-schema.ipldsch.json
+++ b/specs/schemas/schema-schema.ipldsch.json
@@ -315,7 +315,7 @@
 			"representation": {
 				"kinded": {
 					"string": "TypeName",
-					"link": "TypeLink"
+					"map": "TypeLink"
 				}
 			}
 		},

--- a/specs/schemas/schema-schema.ipldsch.json
+++ b/specs/schemas/schema-schema.ipldsch.json
@@ -308,9 +308,9 @@
 		"UnionRepresentation_Kinded": {
 			"kind": "map",
 			"keyType": "RepresentationKind",
-			"valueType": "KindedType"
+			"valueType": "TypeNameOrLink"
 		},
-		"KindedType": {
+		"TypeNameOrLink": {
 			"kind": "union",
 			"representation": {
 				"kinded": {

--- a/specs/schemas/schema-schema.ipldsch.json
+++ b/specs/schemas/schema-schema.ipldsch.json
@@ -441,7 +441,8 @@
 					"discriminantKey": "kind",
 					"discriminantTable": {
 						"map": "TypeMap",
-						"list": "TypeList"
+						"list": "TypeList",
+						"link": "TypeLink"
 					}
 				}
 			}


### PR DESCRIPTION
This is https://github.com/ipld/specs/pull/371, but here.

---

e.g.

```
type Foo union {
  | &Blip link
  | Blop string
} representation kinded
```

rather than having to `type BlipLink &Blip` before using it in a kinded union.

---

I've been using this pattern already, e.g. https://github.com/ipld/specs/blob/9bab36f7c256ae8ff14e0190ff0327e631ef2e15/data-structures/hashmap.md#L113-L116

I think I assumed we had this locked in but I guess we never got it into schema-schema. Without this, to use a link to another type you've defined, you have to make a new link type for it `type HashMapNodeLink &HashMapNode`.