### PR TITLE
fix: byteprefix union representation AST form fix

### DIFF
--- a/_legacy/specs/data-structures/filecoin/basic_types.md
+++ b/_legacy/specs/data-structures/filecoin/basic_types.md
@@ -88,7 +88,7 @@ type CborEncodedReturn Bytes
 
 ```ipldsch
 type Signature union {
-  SignatureSecp256k1 1
-  SignatureBLS 2
-} representation byteprefix
+  SignatureSecp256k1 "01"
+  SignatureBLS "02"
+} representation bytesprefix
 ```

--- a/docs/schemas/features/representation-strategies.md
+++ b/docs/schemas/features/representation-strategies.md
@@ -601,15 +601,15 @@ The `byteprefix` Union representation strategy is used strictly for Bytes repres
 
 ```ipldsch
 type Signature union {
-  | Secp256k1Signature 0
-  | Bls12_381Signature 1
+  | Secp256k1Signature "0x00"
+  | Bls12_381Signature "0x01"
 } representation byteprefix
 
 type Secp256k1Signature bytes
 type Bls12_381Signature bytes
 ```
 
-At the Data Model layer, this presents as Bytes (a byte array), where the first byte is the discriminator (`0x00` or `0x01`) and the remainder is sliced to form either of the two types depending on the discriminator.
+At the Data Model layer, this presents as Bytes (a byte array), where the first bytes are the discriminator (`0x00` or `0x01`) and the remainder is sliced to form either of the two types depending on the discriminator.
 
 No parameters are available for the `byteprefix` Union representation strategy.
 

--- a/docs/schemas/features/representation-strategies.md
+++ b/docs/schemas/features/representation-strategies.md
@@ -21,7 +21,7 @@ eleventyNavigation:
   * [Union `kinded` Representation](#union-kinded-representation)
   * [Union `envelope` Representation](#union-envelope-representation)
   * [Union `inline` Representation](#union-inline-representation)
-  * [Union `byteprefix` Representation](#union-byteprefix-representation)
+  * [Union `bytesprefix` Representation](#union-bytesprefix-representation)
   * [Enum `string` Representation](#enum-string-representation)
   * [Enum `int` Representation](#enum-int-representation)
 
@@ -100,7 +100,7 @@ The following are the representation strategies built-in to IPLD Schemas:
   - `kinded`: transcribes to varying kinds in the Data Model, see below for details.
   - `envelope`: transcribes to a dual-entry _Map_ in the Data Model.
   - `inline`: transcribes to a _Map_ in the Data Model (and has additional limitations).
-  - `byteprefix`: transcribes to _Bytes_ in the Data Model, only usable for unions of Bytes.
+  - `bytesprefix`: transcribes to _Bytes_ in the Data Model, only usable for unions of Bytes.
 - **Struct**
   - `map`: _(default)_ transcribes to _Map_ in the Data Model.
   - `tuple`: transcribes to _List_ in the Data Model.
@@ -421,7 +421,7 @@ No parameters are available for the `keyed` Union representation strategy.
 
 `kinded` Unions discriminate between constituent types of the Union by inspecting the _representation kind_ present at the current node. Each type in the union must be associated with a unique representation kind and exactly one of these representation kinds must be present at the node for it to be a valid Union of the type in question.
 
-The `kinded` Union representation strategy doesn't introduce any kind of wrapping Map in the serialized form at all. Maps are only present if `map` is one of the kinds listed in the Union. Contrast this with other union representation strategies, all of which use at least one layer of Map in their representation (other than `byteprefix` Unions which are a special case).
+The `kinded` Union representation strategy doesn't introduce any kind of wrapping Map in the serialized form at all. Maps are only present if `map` is one of the kinds listed in the Union. Contrast this with other union representation strategies, all of which use at least one layer of Map in their representation (other than `bytesprefix` Unions which are a special case).
 
 **Example**
 
@@ -452,7 +452,7 @@ This data would also match, as `Bar`:
 12
 ```
 
-The syntax used in the type declaration is different for `kinded` Unions in comparison to other Union representation strategies. `kinded` Unions list a representation kind, unquoted, unlike other representation strategies which list a quoted key or discriminator (other than `byteprefix` Unions, a special case).
+The syntax used in the type declaration is different for `kinded` Unions in comparison to other Union representation strategies. `kinded` Unions list a representation kind, unquoted, unlike other representation strategies which list a quoted key or discriminator (other than `bytesprefix` Unions, a special case).
 
 The kind listed after each element of the Union must be a valid representation kind, that is, a kind at the Data Model layer, such as `string` and `map`. Schema kinds are not valid as they don't denote representation kinds (i.e. `struct` would not be a valid kind for a `kinded` Union).
 
@@ -591,19 +591,19 @@ One general parameter is mandatory for the `inline` Union representation strateg
 
 * `discriminantKey` defines a quoted string that is used to look up a string in the Map at the current node to match against the keys provided with each of the constituent types of the Union.
 
-### Union `byteprefix` Representation
+### Union `bytesprefix` Representation
 
 **Representation Kind: Bytes**
 
-The `byteprefix` Union representation strategy is used strictly for Bytes representation kinds. As there are currently no representation strategies other than the default for Bytes that encode as Bytes at the Data Model layer, the `byteprefix` Union representation strategy can only be used as a Union between named Bytes types.
+The `bytesprefix` Union representation strategy is used strictly for Bytes representation kinds. As there are currently no representation strategies other than the default for Bytes that encode as Bytes at the Data Model layer, the `bytesprefix` Union representation strategy can only be used as a Union between named Bytes types.
 
 **Example**
 
 ```ipldsch
 type Signature union {
-  | Secp256k1Signature "0x00"
-  | Bls12_381Signature "0x01"
-} representation byteprefix
+  | Secp256k1Signature "00"
+  | Bls12_381Signature "01"
+} representation bytesprefix
 
 type Secp256k1Signature bytes
 type Bls12_381Signature bytes
@@ -611,7 +611,7 @@ type Bls12_381Signature bytes
 
 At the Data Model layer, this presents as Bytes (a byte array), where the first bytes are the discriminator (`0x00` or `0x01`) and the remainder is sliced to form either of the two types depending on the discriminator.
 
-No parameters are available for the `byteprefix` Union representation strategy.
+No parameters are available for the `bytesprefix` Union representation strategy.
 
 ### Enum `string` Representation
 

--- a/docs/schemas/using/authoring-guide.md
+++ b/docs/schemas/using/authoring-guide.md
@@ -29,7 +29,7 @@ eleventyNavigation:
     * [Keyed](#keyed)
     * [Envelope](#envelope)
     * [Inline](#inline)
-  * [Byteprefix Unions for Bytes](#byteprefix-unions-for-bytes)
+  * [Bytesprefix Unions for Bytes](#bytesprefix-unions-for-bytes)
 * [Copy](#copy)
 * [Advanced Data Layouts](#advanced-data-layouts)
 * [Schemas in Markdown](#schemas-in-markdown)
@@ -99,7 +99,7 @@ The schema kinds have matching tokens that appear throughout IPLD Schemas. Depen
 * Integer: May appear as `Int` for a component specifier or `int` as a typedef. There are no additional specifiers for integer size or signedness (although this may appear as adjuncts for codegen in the future).
 * Float: May appear as `Float` for a component specifier or `float` as a typedef. There are no additional specifiers for size or byte representation (although this may appear as adjuncts for codegen in the future).
 * String: May appear as `String` for a component specifier or `string` as a typedef. The Data Model assumes unicode. Specific string encodings also appear as representation forms, see below.
-* Bytes: May appear as `Bytes` for a component specifier or `bytes` as a typedef. There are no additional specifiers for byte array length and there is no way to specify a single byte. The `byteprefix` Union representation type is a special case indicating prefix string of one or more bytes dictates the type of the proceeding bytes, see below.
+* Bytes: May appear as `Bytes` for a component specifier or `bytes` as a typedef. There are no additional specifiers for byte array length and there is no way to specify a single byte. The `bytesprefix` Union representation type is a special case indicating prefix string of one or more bytes dictates the type of the proceeding bytes, see below.
 * List: Is inferred by the `[Type]` shorthand for both typedefs and inline component specification. The token "List" is not used in the Schema DSL and all Lists must have value type specified (although Unions allow for significant flexibility here).
 * Map: Is inferred by the `{KeyType:ValueType}` shorthand for both typedefs and inline component specification. The token "Map" is not used in the Schema DSL and all Maps must have key and value type specified (although Unions allow for significant flexibility here).
 * Link: The `&` token prefixing a type is used as a shorthand for links. A generic link to an untyped resource uses the special `&Any`, while a link where there is an expected type to be found uses that type name as a hinting mechanism, `&Foo`. See below and [Links in IPLD Schemas](/docs/schemas/features/links/) for more information.
@@ -773,7 +773,7 @@ type Ping struct {
 
 The interface presented by this Schema is adjusted in comparison to the previous Unions as `Error` is now a Struct with a `message` field.
 
-### Byteprefix Unions for Bytes
+### Bytesprefix Unions for Bytes
 
 A special case union exists for handling Bytes kinds. Where a node contains a byte array (Bytes kind), we may want to discriminate between two different uses of that byte array at the application layer. For example, consider two different encoding schemes where we store a "key" field that is distinct for the each encoding scheme. For practical purposes they are both byte arrays, but at the application layer it helps to have them separated into distinct forms, perhaps so we can make simple assertions about getting the expected key type for the given encoding scheme. There are additional documentation clarity benefits for extracting distinct forms and naming them in a Schema that may factor in to such a decision.
 
@@ -784,17 +784,17 @@ type Authorization struct {
 }
 
 type PublicKey union {
-  | RsaPubkey "0x00"
-  | Ed25519Pubkey "0x01"
-} representation byteprefix
+  | RsaPubkey "00"
+  | Ed25519Pubkey "01"
+} representation bytesprefix
 
 type RsaPubkey bytes
 type Ed25519Pubkey bytes
 ```
 
-By declaring a `byteprefix` union, we specify that the bytes of the byte array found at the `key` node of `Authorization` will discriminate which `type` the public key is. Those first bytes will be expected to be either `0x00` or `0x01`, then the remainder of the byte array will be extracted and encapsulated inside either `RsaPubkey` or `Ed25519Pubkey` depending on the discriminator byte.
+By declaring a `bytesprefix` union, we specify that the bytes of the byte array found at the `key` node of `Authorization` will discriminate which `type` the public key is. Those first bytes will be expected to be either `0x00` or `0x01`, then the remainder of the byte array will be extracted and encapsulated inside either `RsaPubkey` or `Ed25519Pubkey` depending on the discriminator byte.
 
-The discriminator bytes are represented as properly formed hexadecimal strings (with or without the `0x` prefix) of any length greater than zero.
+Discriminators must be at least one byte long and not conflict. They are represented as properly formed hexadecimal strings, using upper-case characters only.
 
 ## Copy
 

--- a/docs/schemas/using/authoring-guide.md
+++ b/docs/schemas/using/authoring-guide.md
@@ -99,7 +99,7 @@ The schema kinds have matching tokens that appear throughout IPLD Schemas. Depen
 * Integer: May appear as `Int` for a component specifier or `int` as a typedef. There are no additional specifiers for integer size or signedness (although this may appear as adjuncts for codegen in the future).
 * Float: May appear as `Float` for a component specifier or `float` as a typedef. There are no additional specifiers for size or byte representation (although this may appear as adjuncts for codegen in the future).
 * String: May appear as `String` for a component specifier or `string` as a typedef. The Data Model assumes unicode. Specific string encodings also appear as representation forms, see below.
-* Bytes: May appear as `Bytes` for a component specifier or `bytes` as a typedef. There are no additional specifiers for byte array length and there is no way to specify a single byte. The `byteprefix` Union representation type is a special case indicating a single byte dictates the type of the proceeding bytes, see below.
+* Bytes: May appear as `Bytes` for a component specifier or `bytes` as a typedef. There are no additional specifiers for byte array length and there is no way to specify a single byte. The `byteprefix` Union representation type is a special case indicating prefix string of one or more bytes dictates the type of the proceeding bytes, see below.
 * List: Is inferred by the `[Type]` shorthand for both typedefs and inline component specification. The token "List" is not used in the Schema DSL and all Lists must have value type specified (although Unions allow for significant flexibility here).
 * Map: Is inferred by the `{KeyType:ValueType}` shorthand for both typedefs and inline component specification. The token "Map" is not used in the Schema DSL and all Maps must have key and value type specified (although Unions allow for significant flexibility here).
 * Link: The `&` token prefixing a type is used as a shorthand for links. A generic link to an untyped resource uses the special `&Any`, while a link where there is an expected type to be found uses that type name as a hinting mechanism, `&Foo`. See below and [Links in IPLD Schemas](/docs/schemas/features/links/) for more information.
@@ -784,15 +784,17 @@ type Authorization struct {
 }
 
 type PublicKey union {
-  | RsaPubkey 0
-  | Ed25519Pubkey 1
+  | RsaPubkey "0x00"
+  | Ed25519Pubkey "0x01"
 } representation byteprefix
 
 type RsaPubkey bytes
 type Ed25519Pubkey bytes
 ```
 
-By declaring a `byteprefix` union, we specify that the first byte of the byte array found at the `key` node of `Authorization` will discriminate which `type` the public key is. That first byte will be sliced off and expected to be either `0x0` or `0x1`, then the remainder of the byte array will be extracted and encapsulated inside either `RsaPubkey` or `Ed25519Pubkey` depending on the discriminator byte.
+By declaring a `byteprefix` union, we specify that the bytes of the byte array found at the `key` node of `Authorization` will discriminate which `type` the public key is. Those first bytes will be expected to be either `0x00` or `0x01`, then the remainder of the byte array will be extracted and encapsulated inside either `RsaPubkey` or `Ed25519Pubkey` depending on the discriminator byte.
+
+The discriminator bytes are represented as properly formed hexadecimal strings (with or without the `0x` prefix) of any length greater than zero.
 
 ## Copy
 

--- a/specs/schemas/schema-schema.ipldsch
+++ b/specs/schemas/schema-schema.ipldsch
@@ -431,9 +431,7 @@ type UnionRepresentation_Inline struct {
 ## byteprefix is an invalid representation for any union that contains a type
 ## that does not have a bytes representation.
 ##
-type UnionRepresentation_BytePrefix struct {
-	discriminantTable {TypeName:Int}
-}
+type UnionRepresentation_BytePrefix {TypeName:Int}
 
 ## TypeStruct describes a type which has a group of fields of varying Type.
 ## Each field has a name, which is used to access its value, similarly to

--- a/specs/schemas/schema-schema.ipldsch
+++ b/specs/schemas/schema-schema.ipldsch
@@ -349,11 +349,11 @@ type TypeUnion struct {
 ## can be mapped onto a serialized format for the IPLD Data Model.
 ##
 ## There are five strategies that can be used to encode a union:
-## "keyed", "envelope", "inline", "byteprefix", and "kinded".
+## "keyed", "envelope", "inline", "bytesprefix", and "kinded".
 ## The "keyed", "envelope", and "inline" strategies are all ways to produce
 ## representations in a map format, using map keys as type discriminators
 ## (some literature may describe this as a "tagged" style of union).
-## The "byteprefix" strategy, only available only for unions in which all
+## The "bytesprefix" strategy, only available only for unions in which all
 ## member types themselves represent as bytes in the data model, uses another
 ## byte as the type discrimination hint (and like the map-oriented strategies,
 ## may also be seen as a form of "tagged" style unions).
@@ -369,7 +369,7 @@ type UnionRepresentation union {
 	| UnionRepresentation_Keyed "keyed"
 	| UnionRepresentation_Envelope "envelope"
 	| UnionRepresentation_Inline "inline"
-	| UnionRepresentation_BytePrefix "byteprefix"
+	| UnionRepresentation_BytesPrefix "bytesprefix"
 } representation keyed
 
 ## "Kinded" union representations describe a bidirectional mapping between
@@ -423,7 +423,7 @@ type UnionRepresentation_Inline struct {
 	discriminantTable {String:TypeName}
 }
 
-## UnionRepresentation_BytePrefix describes a union representation for unions
+## UnionRepresentation_BytesPrefix describes a union representation for unions
 ## whose member types are all bytes. It is encoded to a byte array whose
 ## first bytes are the discriminator and subsequent bytes form the discriminated
 ## type.
@@ -433,14 +433,13 @@ type UnionRepresentation_Inline struct {
 ## Nor is there a requirement that they all be of the same length, although
 ## they must all represent unique prefixes.
 ##
-## While Schema DSL parsers may allow `0x` prefixes to the hexadecimal strings,
-## they should not be present in the internal representation, only valid
-## hexadecimal strings are allowed.
+## Only valid, upper-case, hexadecimal strings representing at least one byte
+## are allowed.
 ##
-## byteprefix is an invalid representation for any union that contains a type
+## bytesprefix is an invalid representation for any union that contains a type
 ## that does not have a bytes representation.
 ##
-type UnionRepresentation_BytePrefix {String:TypeName}
+type UnionRepresentation_BytesPrefix {String:TypeName}
 
 ## TypeStruct describes a type which has a group of fields of varying Type.
 ## Each field has a name, which is used to access its value, similarly to

--- a/specs/schemas/schema-schema.ipldsch
+++ b/specs/schemas/schema-schema.ipldsch
@@ -425,13 +425,22 @@ type UnionRepresentation_Inline struct {
 
 ## UnionRepresentation_BytePrefix describes a union representation for unions
 ## whose member types are all bytes. It is encoded to a byte array whose
-## first byte is the discriminator and subsequent bytes form the discriminated
+## first bytes are the discriminator and subsequent bytes form the discriminated
 ## type.
+##
+## Discriminators are represented as hexadecimal strings. There is currently
+## no limitation on their length, other than needing to be at least one byte.
+## Nor is there a requirement that they all be of the same length, although
+## they must all represent unique prefixes.
+##
+## While Schema DSL parsers may allow `0x` prefixes to the hexadecimal strings,
+## they should not be present in the internal representation, only valid
+## hexadecimal strings are allowed.
 ##
 ## byteprefix is an invalid representation for any union that contains a type
 ## that does not have a bytes representation.
 ##
-type UnionRepresentation_BytePrefix {TypeName:Int}
+type UnionRepresentation_BytePrefix {String:TypeName}
 
 ## TypeStruct describes a type which has a group of fields of varying Type.
 ## Each field has a name, which is used to access its value, similarly to

--- a/specs/schemas/schema-schema.ipldsch.json
+++ b/specs/schemas/schema-schema.ipldsch.json
@@ -356,8 +356,8 @@
 		},
 		"UnionRepresentation_BytePrefix": {
 			"kind": "map",
-			"keyType": "TypeName",
-			"valueType": "Int"
+			"keyType": "String",
+			"valueType": "TypeName"
 		},
 		"TypeStruct": {
 			"kind": "struct",

--- a/specs/schemas/schema-schema.ipldsch.json
+++ b/specs/schemas/schema-schema.ipldsch.json
@@ -355,19 +355,9 @@
 			}
 		},
 		"UnionRepresentation_BytePrefix": {
-			"kind": "struct",
-			"fields": {
-				"discriminantTable": {
-					"type": {
-						"kind": "map",
-						"keyType": "TypeName",
-						"valueType": "Int"
-					}
-				}
-			},
-			"representation": {
-				"map": {}
-			}
+			"kind": "map",
+			"keyType": "TypeName",
+			"valueType": "Int"
 		},
 		"TypeStruct": {
 			"kind": "struct",

--- a/specs/schemas/schema-schema.ipldsch.json
+++ b/specs/schemas/schema-schema.ipldsch.json
@@ -301,7 +301,7 @@
 					"keyed": "UnionRepresentation_Keyed",
 					"envelope": "UnionRepresentation_Envelope",
 					"inline": "UnionRepresentation_Inline",
-					"byteprefix": "UnionRepresentation_BytePrefix"
+					"bytesprefix": "UnionRepresentation_BytesPrefix"
 				}
 			}
 		},
@@ -354,7 +354,7 @@
 				"map": {}
 			}
 		},
-		"UnionRepresentation_BytePrefix": {
+		"UnionRepresentation_BytesPrefix": {
 			"kind": "map",
 			"keyType": "String",
 			"valueType": "TypeName"


### PR DESCRIPTION
This is https://github.com/ipld/specs/pull/370, but here

---

discovered while trying to use via TypeScript @ https://github.com/ipld/js-ipld-schema/pull/37 -> https://github.com/rvagg/js-ipld-schema-validator/pull/4