### PR TITLE
links to schema spec content

### DIFF
--- a/docs/schemas/index.md
+++ b/docs/schemas/index.md
@@ -10,5 +10,18 @@ IPLD Schemas
 IPLD Schemas are an interface definition language which provides a way to do structural typing for data structures.
 They're meant to be useful as a _design language_, and meant to make specifying protocols easier -- especially, decentralized protocols.
 
+:::info
+This is a _docs_ chapter, contrasted with a _specs_ chapter -- if you want more mechanical details
+(including, especially, the schema-schema!),
+you may prefer to jump over to [Schemas in the specs chapters](/specs/schemas/) instead.
+:::
+
+We have materials in this chapter of the documentation for overviews on what Schemas are, what makes them unique,
+how to use them, and, how to use them _effectively_.
+
+---
+
 {% import "listing.njk" as listing %}
 {{ listing.childrenTableWithSynopsys(collections.all, page.url) }}
+
+---

--- a/specs/schemas/index.md
+++ b/specs/schemas/index.md
@@ -6,14 +6,27 @@ eleventyNavigation:
 ---
 
 IPLD Schema Specifications
-====================
+==========================
 
-:::todo
-- Schema content still conflates docs and specs, so we have little here in the specs directory at the moment.
-- The schema-schema and other examples are here, but auto-linking doesn't point to them.  Do something about this.
+Here are collected the specifications and fixtures for IPLD Schemas.
+
+:::info
+This is a _specs_ chapter, rather than a _docs_ chapter.  It's geared for in-depth details.
+
+For more introductory and human-friendly material on Schemas -- what they are, what they do, and how to use them -- see [Schemas in the docs chapters](/docs/schemas/) instead.)
 :::
 
----
+The IPLD Schema specification is self-hosting: it is primarily described by the "schema schema".
 
-{% import "listing.njk" as listing %}
-{{ listing.childrenTableWithSynopsys(collections.all, page.url) }}
+- The schema-schema can be seen in two forms, in DSL form, or as the equivalent parsed Schema DMT in JSON encoding:
+	- [schema-schema.ipldsch](./schema-schema.ipldsch)
+	- [schema-schema.ipldsch.json](./schema-schema.ipldsch.json)
+
+Additional material:
+
+- Examples:
+	- An example Schema, in DSL form, with matching parsed Schema DMT in JSON encoding:
+		- [examples.ipldsch](./examples.ipldsch)
+		- [examples.ipldsch.json](./examples.ipldsch.json)
+- Fixtures:
+	- Aside from the schema-schema and examples above, more fixtures for this system are currently lacking.  If you know of some and can link them here, or are willing to write some, please send an issue or PR.


### PR DESCRIPTION
Crosslink schema docs and schema specs, and actually link schema specs content.

It's necessary to do the schema specs content linking manually,
because the eleventy autogen stuff we've been using for other kinds of
content only works for the markdown content pages (or stuff with
frontmatter, perhaps, but that still excludes these files).

Spartan, but makes the content reachable.  Previously it was not.