### PR TITLE
clean up child listings

### DIFF
--- a/.site/_includes/listing.njk
+++ b/.site/_includes/listing.njk
@@ -8,12 +8,12 @@
 {% macro childrenTableWithSynopsys(collectionsAll, pageUrl) -%}
 {% set navPages = collectionsAll | eleventyNavigation(pageUrl) %}
 {{ collections.all | dump }}
-<table cellspacing=6>
+<table cellspacing=6 class="children-table">
 {%- for entry in navPages %}
 	<tr>
-	<td align="right" style="font-size: 120%;"><a href="{{ entry.url | url }}">{{ entry.title }}</a></td>
-	<td> - </td>
-	<td>{{ entry.synopsys if entry.synopsys else "<i><small>no synopsys available</small></i>" | safe }}</td>
+	<td><a href="{{ entry.url | url }}">{{ entry.title }}</a></td>
+	<td>{{ " - " if entry.synopsys }}</td>
+	<td>{{ entry.synopsys if entry.synopsys | safe }}</td>
 	</tr>
 {%- endfor -%}
 </table>

--- a/.site/css/layout.css
+++ b/.site/css/layout.css
@@ -132,3 +132,12 @@ aside#breadcrumbs {
 	content: " » ";
 	margin: 0 0.4rem;
 }
+
+.children-table > tbody > tr > td:first-child {
+	text-align: right;
+	font-weight: bold;
+}
+
+.children-table > tbody > tr > td {
+	vertical-align: middle;
+}


### PR DESCRIPTION
I originally wanted to do this just to get vertical alignment in the table fixed, but while in there I swapped the `font-size: 120%` for a `font-weight: bold` and IMO it's much more pleasant on the eyes. It also removes the "no synopsys available" since we have very few synopses in the entire site so this shows up far too much.

Thoughts?

<img width="920" alt="Screenshot 2021-07-13 at 10 56 10 am" src="https://user-images.githubusercontent.com/495647/125373751-0a8ee280-e3c9-11eb-97f3-125e005c98e1.png">
