### PR TITLE
Add "schema-schema" make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,10 @@ build:
 	@echo ">>> $@ >>>"
 	npm run build
 
+schema-schema:
+	@ echo ">>> $@ >>>"
+	npm run build:schema-schema
+
 dev:
 	@echo ">>> $@ >>>"
 	npm run dev

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "fetch-hyperlink:darwin": "wget -q https://github.com/untitaker/hyperlink/releases/download/0.1.15/hyperlink-mac-x86_64 -O .site/_tools/hyperlink && chmod +x .site/_tools/hyperlink",
     "fetch-hyperlink:linux": "wget -q https://github.com/untitaker/hyperlink/releases/download/0.1.15/hyperlink-linux-x86_64 -O .site/_tools/hyperlink && chmod +x .site/_tools/hyperlink",
     "build": "cd .site && eleventy",
+    "build:schema-schema": "npm_config_yes=true npx ipld-schema to-json -t specs/schemas/schema-schema.ipldsch > specs/schemas/schema-schema.ipldsch.json",
     "dev": "cd .site && eleventy --serve",
     "clean": "rm -rf .site/_output",
     "publish": "echo 'Just push!  Fleek will pick it up from github.' && exit 1"


### PR DESCRIPTION
We shouldn't have to touch schema-schema.ipldsch.json _unless_ we're making fundamental changes that break the JS parser.