### PR TITLE
Bring back explicit `map` and `list` keywords for type defns

### DIFF
--- a/_legacy/specs/block-layer/graphsync/known_extensions.md
+++ b/_legacy/specs/block-layer/graphsync/known_extensions.md
@@ -18,7 +18,7 @@ When a requestor sends a request, it should send a CBOR encoded IPLD Node that i
 The IPLD schema is as follows:
 
 ```ipldsch
-type DoNotSendCids [Cid]
+type DoNotSendCids list [Cid]
 ```
 
 The responder node will execute the selector query as it would normally. However, if it supports the extension, when the selector query passes over any blocks that have a cid from the DoNotSend list, the responder will not send that block back, knowing ahead of time the requestor already has it. The responder does not send a value back in the response for this extension.
@@ -59,5 +59,5 @@ type LinkMetadata struct {
   blockPresent Bool
 }
 
-type ResponseMetadata [LinkMetadata]
+type ResponseMetadata list [LinkMetadata]
 ```

--- a/_legacy/specs/data-structures/filecoin/chain.md
+++ b/_legacy/specs/data-structures/filecoin/chain.md
@@ -55,7 +55,7 @@ contains a single parent CID referring to the `Genesis` (above, CID
 type StateRootLink &Any
 
 # See note above about the single case where this type hint does not hold true.
-type TipSetKey [&BlockHeader]
+type TipSetKey list [&BlockHeader]
 
 type BlockHeader struct {
   Miner Address
@@ -264,7 +264,7 @@ type ActorsHAMTElement union {
 
 type ActorsHAMTLink &ActorsHAMT
 
-type ActorsHAMTBucket [ ActorsHAMTBucketEntry ]
+type ActorsHAMTBucket list [ ActorsHAMTBucketEntry ]
 
 type ActorsHAMTBucketEntry struct {
   key Address

--- a/_legacy/specs/data-structures/filecoin/state.md
+++ b/_legacy/specs/data-structures/filecoin/state.md
@@ -79,7 +79,7 @@ type ActorIDHAMTElement union {
 
 type ActorIDHAMTLink &ActorIDHAMT
 
-type ActorIDHAMTBucket [ ActorIDHAMTBucketEntry ]
+type ActorIDHAMTBucket list [ ActorIDHAMTBucketEntry ]
 
 type ActorIDHAMTBucketEntry struct {
   key Address
@@ -346,7 +346,7 @@ type DealProposalHAMTElement union {
 
 type DealProposalHAMTLink &DealProposalHAMT
 
-type DealProposalHAMTBucket [ DealProposalHAMTBucketEntry ]
+type DealProposalHAMTBucket list [ DealProposalHAMTBucketEntry ]
 
 type DealProposalHAMTBucketEntry struct {
   key DealCidBytes
@@ -369,7 +369,7 @@ type BalanceTableHAMTElement union {
 
 type BalanceTableHAMTLink &BalanceTableHAMT
 
-type BalanceTableHAMTBucket [ BalanceTableHAMTBucketEntry ]
+type BalanceTableHAMTBucket list [ BalanceTableHAMTBucketEntry ]
 
 type BalanceTableHAMTBucketEntry struct {
   key Address
@@ -394,7 +394,7 @@ type DealOpsByEpochHAMTElement union {
 
 type DealOpsByEpochHAMTLink &DealOpsByEpochHAMTLink
 
-type DealOpsByEpochHAMTBucket [ DealOpsByEpochHAMTBucketEntry ]
+type DealOpsByEpochHAMTBucket list [ DealOpsByEpochHAMTBucketEntry ]
 
 type DealOpsByEpochHAMTBucketEntry struct {
   key ChainEpochBytes
@@ -415,7 +415,7 @@ type DealOpsByEpochHAMTSetElement union {
 
 type DealOpsByEpochHAMTSet_Link &DealOpsByEpochHAMTSet
 
-type DealOpsByEpochHAMTSetBucket [ DealOpsByEpochHAMTSetBucketEntry ]
+type DealOpsByEpochHAMTSetBucket list [ DealOpsByEpochHAMTSetBucketEntry ]
 
 type DealOpsByEpochHAMTSetBucketEntry struct {
   key DealIDBytes
@@ -535,7 +535,7 @@ type MinerV0Deadlines struct {
 } representation tuple
 
 # Must be 48 CIDs
-type MinerV0DeadlineLinkList [&MinerV0Deadline]
+type MinerV0DeadlineLinkList list [&MinerV0Deadline]
 ```
 
 ```ipldsch
@@ -657,7 +657,7 @@ type MinerV2Deadlines struct {
 } representation tuple
 
 # Must be 48 CIDs
-type MinerV2DeadlineLinkList [&MinerV2Deadline]
+type MinerV2DeadlineLinkList list [&MinerV2Deadline]
 ```
 
 ```ipldsch
@@ -702,7 +702,7 @@ type MinerV0SectorPreCommitOnChainInfoHAMTElement union {
 
 type MinerV0SectorPreCommitOnChainInfoHAMTLink &MinerV0SectorPreCommitOnChainInfoHAMT
 
-type MinerV0SectorPreCommitOnChainInfoHAMTBucket [ MinerV0SectorPreCommitOnChainInfoHAMTBucketEntry ]
+type MinerV0SectorPreCommitOnChainInfoHAMTBucket list [ MinerV0SectorPreCommitOnChainInfoHAMTBucketEntry ]
 
 type MinerV0SectorPreCommitOnChainInfoHAMTBucketEntry struct {
   key SectorNumberBytes
@@ -1024,7 +1024,7 @@ type MultisigV0TransactionHAMTElement union {
 
 type MultisigV0TransactionHAMTLink &MultisigV0TransactionHAMT
 
-type MultisigV0TransactionHAMTBucket [ MultisigV0TransactionHAMTBucketEntry ]
+type MultisigV0TransactionHAMTBucket list [ MultisigV0TransactionHAMTBucketEntry ]
 
 type MultisigV0TransactionHAMTBucketEntry struct {
   key Bytes
@@ -1192,7 +1192,7 @@ type PowerV0CronEventHAMTElement union {
 
 type PowerV0CronEventHAMTLink &PowerV0CronEventHAMTLink
 
-type PowerV0CronEventHAMTBucket [ PowerV0CronEventHAMTBucketEntry ]
+type PowerV0CronEventHAMTBucket list [ PowerV0CronEventHAMTBucketEntry ]
 
 type PowerV0CronEventHAMTBucketEntry struct {
   key ChainEpochBytes
@@ -1235,7 +1235,7 @@ type PowerV0ClaimMapHAMTElement union {
 
 type PowerV0ClaimMapHAMTLink &PowerV0ClaimMapHAMT
 
-type PowerV0ClaimMapHAMTBucket [ PowerV0ClaimMapHAMTBucketEntry ]
+type PowerV0ClaimMapHAMTBucket list [ PowerV0ClaimMapHAMTBucketEntry ]
 
 type PowerV0ClaimMapHAMTBucketEntry struct {
   key Address
@@ -1265,7 +1265,7 @@ type PowerV2ClaimMapHAMTElement union {
 
 type PowerV2ClaimMapHAMTLink &PowerV2ClaimMapHAMT
 
-type PowerV2ClaimMapHAMTBucket [ PowerV2ClaimMapHAMTBucketEntry ]
+type PowerV2ClaimMapHAMTBucket list [ PowerV2ClaimMapHAMTBucketEntry ]
 
 type PowerV2ClaimMapHAMTBucketEntry struct {
   key Address
@@ -1299,7 +1299,7 @@ type ProofValidationBatchHAMTElement union {
 
 type ProofValidationBatchHAMTLink &ProofValidationBatchHAMTLink
 
-type ProofValidationBatchHAMTBucket [ ProofValidationBatchHAMTBucketEntry ]
+type ProofValidationBatchHAMTBucket list [ ProofValidationBatchHAMTBucketEntry ]
 
 type ProofValidationBatchHAMTBucketEntry struct {
   key Address
@@ -1381,7 +1381,7 @@ type DataCapHAMTElement union {
 
 type DataCapHAMTLink &DataCapHAMT
 
-type DataCapHAMTBucket [ DataCapHAMTBucketEntry ]
+type DataCapHAMTBucket list [ DataCapHAMTBucketEntry ]
 
 type DataCapHAMTBucketEntry struct {
   key Address

--- a/docs/schemas/features/indicating-adls.md
+++ b/docs/schemas/features/indicating-adls.md
@@ -46,7 +46,7 @@ Similarly, an advanced layout implementing a sharded `map` may be defined and us
 ```ipldsch
 advanced ShardedMap
 
-type MyMap { String : &Any } representation advanced ShardedMap
+type MyMap map { String : &Any } representation advanced ShardedMap
 ```
 
 From this usage, we may infer that `ShardedMap` can (1) present a familiar `map` kind interface and (2) store `link`s as values (with no specific "expectedType"), referenced by standard data model `string`s. Other operating modes for `ShardedMap` may also be possible (it may be able to store other value kinds, or it may even be able to act as a `bytes` kind in spite of its name!).

--- a/docs/schemas/features/representation-strategies.md
+++ b/docs/schemas/features/representation-strategies.md
@@ -303,7 +303,7 @@ Schema Maps are represented as Data Model Maps by default. Schema Maps differ fr
 **Example**
 
 ```ipldsch
-type FloatMap {String:Float}
+type FloatMap map {String:Float}
 ```
 
 Some data matching the `FloatMap` Map (shown as JSON) is:
@@ -333,7 +333,7 @@ This serial representation is strictly limited: the domain of available for keys
 A string that is similar in format to the options found in an /etc/fstab file might be defined as:
 
 ```ipldsch
-type MountOptions {String:String} representation stringpairs {
+type MountOptions map {String:String} representation stringpairs {
   innerDelim "="
   entryDelim ","
 }
@@ -359,7 +359,7 @@ The `listpairs` Map representation strategy is roughly the same the `listpairs` 
 **Example**
 
 ```ipldsch
-type FloatMap {String:Float} representation listpairs
+type FloatMap map {String:Float} representation listpairs
 ```
 
 Some data matching the `FloatMap` Map (shown as JSON) is:
@@ -473,7 +473,7 @@ type Foo struct {
 
 type Bar int
 
-type Bang {String:Int} representation stringpairs {
+type Bang map {String:Int} representation stringpairs {
   innerDelim ":"
   entryDelim "|"
 }

--- a/docs/schemas/intro/feature-summary.md
+++ b/docs/schemas/intro/feature-summary.md
@@ -61,7 +61,7 @@ type Foo struct {
   f nullable Bar
 }
 
-type Bar [nullable Foo]
+type Bar list [nullable Foo]
 ```
 
 **A clear syntax for non-required fields**

--- a/docs/schemas/using/authoring-guide.md
+++ b/docs/schemas/using/authoring-guide.md
@@ -126,13 +126,13 @@ The non-recursive (scalar) Schema kinds (Boolean, Integer, Float, String, Bytes,
 ```ipldsch
 type Foo string
 type Bar int
-type Boom {Foo:Bar}
+type Boom map {Foo:Bar}
 ```
 
 In terms of data layout, this is equivalent to:
 
 ```ipldsch
-type Boom {String:Int}
+type Boom map {String:Int}
 ```
 
 (Note that even though the Data Model only allows for string keys of maps, the indirection through type `Foo` is allowed since it has a string representation.)
@@ -158,9 +158,9 @@ For more information about Links in Schemas, see [Links in IPLD Schemas](/docs/s
 The scalar types (Boolean, Integer, Float, String, Bytes, Link) may appear inline or be typedef'd. In addition, both Map and Link types may appear both inline and as their own type. The additional Schema kinds (Struct, Enum, Union, Copy) do not have an inline variant.
 
 ```ipldsch
-type IntList [Int]
+type IntList list [Int]
 
-type MapOfIntLists {String:IntList}
+type MapOfIntLists map {String:IntList}
 
 type Foo struct {
   id Int
@@ -852,7 +852,7 @@ The interaction with the Data Model is also left up to the ADL, so it is not lim
 ```ipldsch
 advanced ShardedMap
 
-type MyMap { String : &Any } representation advanced ShardedMap
+type MyMap map { String : &Any } representation advanced ShardedMap
 ```
 
 In this case, we declare a `MyMap` type that is considered a Map kind for the purpose of the rest of the Schema and presents as such above the Schema layer. Meanwhile we have inserted custom logic, labelled `ShardedMap`, that takes care of the decode/encode and traversal required to present a standard Map kind to the user of such a Schema.

--- a/specs/advanced-data-layouts/fbl/spec.md
+++ b/specs/advanced-data-layouts/fbl/spec.md
@@ -13,7 +13,7 @@ type FlexibleByteLayout union {
   | &FlexibleByteLayout link
 } representation kinded
 
-type NestedByteList [ NestedByte ]
+type NestedByteList list [ NestedByte ]
 
 type NestedByte union {
   | Bytes bytes

--- a/specs/advanced-data-layouts/hamt/fixture/alice-words/index.md
+++ b/specs/advanced-data-layouts/hamt/fixture/alice-words/index.md
@@ -18,7 +18,7 @@ This fixture builds a HAMT cataloging the locations of all words appearing in th
 * Values take the following form:
 
 ```ipldsch
-type Value [Datum]
+type Value list [Datum]
 type Datum struct {
   line Int
   column Int

--- a/specs/advanced-data-layouts/hamt/spec.md
+++ b/specs/advanced-data-layouts/hamt/spec.md
@@ -115,7 +115,7 @@ type Element union {
   | Bucket list
 } representation kinded
 
-type Bucket [ BucketEntry ]
+type Bucket list [ BucketEntry ]
 
 type BucketEntry struct {
   key Bytes
@@ -339,7 +339,7 @@ type PointerV3 union {
   | Bucket list
 } representation kinded
 
-type Bucket [ KV ]
+type Bucket list [ KV ]
 
 # Equivalent to "BucketEntry"
 type KV struct {

--- a/specs/codecs/dag-eth/chain.md
+++ b/specs/codecs/dag-eth/chain.md
@@ -77,7 +77,7 @@ This is the IPLD schema for a list of uncles ordered in ascending order by their
 ```ipldsch
 # Uncles contains an ordered list of Ethereum uncles (headers that have no associated body)
 # This IPLD object is referenced by a CID composed of the KECCAK_256 multihash of the RLP encoded list and the EthHeaderList codec (0x91)
-type Uncles [Header]
+type Uncles list [Header]
 ```
 
 ## Transaction IPLD
@@ -115,7 +115,7 @@ type Transaction struct {
 }
 
 // AccessList is an EIP-2930 access list.
-type AccessList [AccessElement]
+type AccessList list [AccessElement]
 
 // AccessElement are the element type of an access list.
 type AccessElement struct {
@@ -124,7 +124,7 @@ type AccessElement struct {
 }
 
 // StorageKeys are the keys contained in an AccessElement
-type StorageKeys [Hash]
+type StorageKeys list [Hash]
 ```
 
 ## Receipt IPLD
@@ -156,7 +156,7 @@ type Status enum {
 } representation int
 
 # Logs is a list of logs
-type Logs [Log]
+type Logs list [Log]
 
 # Log contains the consensus fields of an Etherem receipt log
 type Log struct {
@@ -166,5 +166,5 @@ type Log struct {
 }
 
 # Topics is a list of log topics
-type Topics [Hash]
+type Topics list [Hash]
 ```

--- a/specs/codecs/dag-eth/convenience_types.md
+++ b/specs/codecs/dag-eth/convenience_types.md
@@ -106,7 +106,7 @@ This is the IPLD schema for the ordered list of all transactions for a given blo
 
 ```ipldsch
 # Transactions contains a list of all of the Ethereum transactions at this block
-type Transactions [&Transaction]
+type Transactions list [&Transaction]
 ```
 
 ## Receipts IPLD
@@ -118,7 +118,7 @@ This is the IPLD schema for the ordered list of all receipts for a given block.
 
 ```ipldsch
 # Receipts contains a list of all of the receipts at this block
-type Receipts [Receipt]
+type Receipts list [Receipt]
 ```
 
 ## Genesis IPLD
@@ -154,7 +154,7 @@ type GenesisInfo struct {
 }
 
 # GenesisAlloc is a map that specifies the initial state that is part of the genesis block.
-type GenesisAlloc {Address:GenesisAccount}
+type GenesisAlloc map {Address:GenesisAccount}
 
 # GenesisAccount is an account in the state of the genesis block.
 type GenesisAccount struct {

--- a/specs/schemas/examples.ipldsch
+++ b/specs/schemas/examples.ipldsch
@@ -1,5 +1,5 @@
 
-type ExampleWithNullable {String : nullable &Any}
+type ExampleWithNullable map {String : nullable &Any}
 
 type ExampleWithAnonDefns struct {
 	fooField optional {String:String} (rename "foo_field")

--- a/specs/schemas/schema-schema.ipldsch
+++ b/specs/schemas/schema-schema.ipldsch
@@ -31,7 +31,7 @@ type TypeName string
 ## }
 ## ```
 ##
-type SchemaMap {TypeName:Type}
+type SchemaMap map {TypeName:Type}
 
 ## AdvancedDataLayoutName defines the name of an ADL as a string.
 ##
@@ -47,7 +47,7 @@ type AdvancedDataLayoutName string
 ## maps the name (AdvancedDataLayoutName) to the AdvancedDataLayout, which is
 ## currently an empty map.
 ##
-type AdvancedDataLayoutMap {AdvancedDataLayoutName:AdvancedDataLayout}
+type AdvancedDataLayoutMap map {AdvancedDataLayoutName:AdvancedDataLayout}
 
 ## Schema is a single-member union, which can be used in serialization
 ## to make a form of "nominative type declaration".
@@ -378,7 +378,7 @@ type UnionRepresentation union {
 ##
 ## The referenced type must of course produce the RepresentationKind it's
 ## matched with!
-type UnionRepresentation_Kinded {RepresentationKind:TypeName}
+type UnionRepresentation_Kinded map {RepresentationKind:TypeName}
 
 ## "Keyed" union representations will encode as a map, where the map has
 ## exactly one entry, the key string of which will be used to look up the name
@@ -388,7 +388,7 @@ type UnionRepresentation_Kinded {RepresentationKind:TypeName}
 ## over the other styles wherever possible; keyed unions tend to have good
 ## performance characteristics, as they have most "mechanical sympathy" with
 ## parsing and deserialization implementation order.
-type UnionRepresentation_Keyed {String:TypeName}
+type UnionRepresentation_Keyed map {String:TypeName}
 
 ## "Envelope" union representations will encode as a map, where the map has
 ## exactly two entries: the two keys should be of the exact strings specified
@@ -681,14 +681,14 @@ type EnumRepresentation union {
 ## in the DSL) which will be stored here in the representation block. Missing
 ## entries in this map will use the default.
 ##
-type EnumRepresentation_String {EnumValue:String}
+type EnumRepresentation_String map {EnumValue:String}
 
 ## EnumRepresentation_Int describes the way an enum is represented as an int
 ## in the data model. A mapping of names to ints is required to perform the
 ## conversion from int to enum value. In the DSL, int values _must_ be provided
 ## for each EnumValue (with `Foo ("100")`, those are stored here.
 ##
-type EnumRepresentation_Int {EnumValue:Int}
+type EnumRepresentation_Int map {EnumValue:Int}
 
 ## TypeCopy describes a special "copy" unit that indicates that a type name
 ## should copy the type descriptor of another type. TypeCopy does not redirect a

--- a/specs/selectors/index.md
+++ b/specs/selectors/index.md
@@ -161,7 +161,7 @@ type ExploreRecursiveEdge struct {}
 ## be considered part of a (possibly labelled) result set), while simultaneously
 ## continuing to explore deeper parts of the tree with another selector,
 ## for example.
-type ExploreUnion [Selector]
+type ExploreUnion list [Selector]
 
 ## Note that ExploreConditional versus a Matcher with a Condition are distinct:
 ## ExploreConditional progresses deeper into a tree;


### PR DESCRIPTION
The shorthand is annoying @warpfork enough that he wants these back (they were originally). It is easier to parse this way, but it makes them slightly more verbose. The most notable verbosity in the changes below is `type MyMap map { String : &Any } representation advanced ShardedMap`, whoa boy.

This doesn't do away with the inline definition style, just when you're declaring a `type`.

There's also a matter of `type FooLink &Foo` which is now an outlier .. should it be `type FooLink link &Foo` or something more verbose like `type FooLink link { expectedType Foo }`, which would more explicitly match schema-schema, but would also drive you to use inline forms because this might be unreasonably verbose.