### PR TITLE
Remove extra leading comment for consistency

### DIFF
--- a/specs/schemas/schema-schema.ipldsch
+++ b/specs/schemas/schema-schema.ipldsch
@@ -3,7 +3,6 @@
 ## Yes, it's self-describing! :)
 ## -----
 
-##
 ## Type names are a simple alias of string.
 ##
 ## There are some additional rules that should be applied. Type names:


### PR DESCRIPTION
helps with simple parsing of this doc to pull out the sections, don't lead with extra blank comment lines

very minor, and I thought we'd already done this (I have a copy in another repo that has this fix already)