### PR TITLE
Schema schema synchronization

### DIFF
--- a/glossary.md
+++ b/glossary.md
@@ -100,6 +100,22 @@ we've just added `bytes` for binary, and this `link` kind, which gives IPLD a lo
 
 There is a `link` kind is implemented by [CID](#cid)s.
 
+#### DMT
+
+DMT is short for "**D**ata **M**odel **T**ree".
+It is a term we coined in IPLD to describe data that's -- well -- in the [Data Model](#data-model) form.
+
+The term "DMT" is usually only used when necessary for differentiation:
+for example, we might say: "this data isn't in JSON form anymore; we've parsed it into DMT form".
+Another example sentence might be: "this data was created with a library DSL, but really, its true form is a standard DMT".
+And so on.
+
+The concept of DMT could also be compared to the computer science concept of an [AST](https://en.wikipedia.org/wiki/Abstract_syntax_tree),
+but again, sometimes a unique term is useful for disambiguation.
+For example: "the DSL AST is somewhat richer than the DMT; the DMT only describes the logical elements of the document rather than the whole syntax used to specify them".
+(We also find the term "AST" somewhat of a bad match for what we mean by DMTs in IPLD,
+because an IPLD DMT is explicitly codec agnostic (in other words, syntax agnostic!), which doesn't line up well with the "S" in "AST".)
+
 #### Link
 
 A link is just another name for a [CID](#cid).

--- a/specs/schemas/examples.ipldsch
+++ b/specs/schemas/examples.ipldsch
@@ -8,3 +8,7 @@ type ExampleWithAnonDefns struct {
 	wozField {String:[nullable String]}
 	boomField &ExampleWithNullable
 } representation map
+
+type ExampleOfUnit unit representation null
+
+type ExampleOfAny any

--- a/specs/schemas/examples.ipldsch.json
+++ b/specs/schemas/examples.ipldsch.json
@@ -1,74 +1,83 @@
 {
 	"schema": {
 		"ExampleWithNullable": {
-			"kind": "map",
-			"keyType": "String",
-			"valueType": {
-				"kind": "link"
-			},
-			"valueNullable": true
+			"map": {
+				"keyType": "String",
+				"valueType": {
+					"link": {}
+				},
+				"valueNullable": true
+			}
 		},
 		"ExampleWithAnonDefns": {
-			"kind": "struct",
-			"fields": {
-				"fooField": {
-					"type": {
-						"kind": "map",
-						"keyType": "String",
-						"valueType": "String"
+			"struct": {
+				"fields": {
+					"fooField": {
+						"type": {
+							"map": {
+								"keyType": "String",
+								"valueType": "String"
+							}
+						},
+						"optional": true
 					},
-					"optional": true
-				},
-				"barField": {
-					"type": {
-						"kind": "map",
-						"keyType": "String",
-						"valueType": "String"
+					"barField": {
+						"type": {
+							"map": {
+								"keyType": "String",
+								"valueType": "String"
+							}
+						},
+						"nullable": true
 					},
-					"nullable": true
-				},
-				"bazField": {
-					"type": {
-						"kind": "map",
-						"keyType": "String",
-						"valueType": "String",
-						"valueNullable": true
-					}
-				},
-				"wozField": {
-					"type": {
-						"kind": "map",
-						"keyType": "String",
-						"valueType": {
-							"kind": "list",
-							"valueType": "String",
-							"valueNullable": true
+					"bazField": {
+						"type": {
+							"map": {
+								"keyType": "String",
+								"valueType": "String",
+								"valueNullable": true
+							}
+						}
+					},
+					"wozField": {
+						"type": {
+							"map": {
+								"keyType": "String",
+								"valueType": {
+									"list": {
+										"valueType": "String",
+										"valueNullable": true
+									}
+								}
+							}
+						}
+					},
+					"boomField": {
+						"type": {
+							"link": {
+								"expectedType": "ExampleWithNullable"
+							}
 						}
 					}
 				},
-				"boomField": {
-					"type": {
-						"kind": "link",
-						"expectedType": "ExampleWithNullable"
-					}
-				}
-			},
-			"representation": {
-				"map": {
-					"fields": {
-						"fooField": {
-							"rename": "foo_field"
+				"representation": {
+					"map": {
+						"fields": {
+							"fooField": {
+								"rename": "foo_field"
+							}
 						}
 					}
 				}
 			}
 		},
 		"ExampleOfUnit": {
-			"kind": "unit",
-			"representation": "null"
+			"unit": {
+				"representation": "null"
+			}
 		},
 		"ExampleOfAny": {
-			"kind": "any"
+			"any": {}
 		}
 	}
 }

--- a/specs/schemas/examples.ipldsch.json
+++ b/specs/schemas/examples.ipldsch.json
@@ -62,6 +62,13 @@
 					}
 				}
 			}
+		},
+		"ExampleOfUnit": {
+			"kind": "unit",
+			"representation": "null"
+		},
+		"ExampleOfAny": {
+			"kind": "any"
 		}
 	}
 }

--- a/specs/schemas/index.md
+++ b/specs/schemas/index.md
@@ -65,3 +65,24 @@ Examples and Fixtures
 		- [examples.ipldsch.json](./examples.ipldsch.json)
 - Fixtures:
 	- Aside from the schema-schema and examples above, more fixtures for this system are currently lacking.  If you know of some and can link them here, or are willing to write some, please send an issue or PR.
+
+
+Bootstrapping a Schema implementation
+-------------------------------------
+
+The schema-schema is intentionally designed to be relatively easy to parse.
+We chose to use features when defining the schema-schema that are the clearest to implement,
+and the most likely to be early selections for a high priority in implementing anyway;
+and we in some cases carefully avoided using features that would've been nice-to-have but technically nonessential.
+
+For example: the schema-schema only uses keyed and kinded unions, which are some of the most clear to implement.
+
+As another example: the schema schema in several places uses `type X struct {}` rather than
+using a `unit` typekind (a la `type X unit representation emptymap`).
+We chose to do this, even though use of a unit type would be more semantically explicit,
+because we figure that one less thing to implement before being able to successfully wrangle the schema-schema
+is probably going to be well-received by anyone implementing schemas in a new language.
+
+It's still probably wise to start with smaller goals than biting off the whole schema-schema at once
+as the first target for bootstrapping a new schema implementation in a new language.
+Still, we hope these choices in the design _help_.

--- a/specs/schemas/index.md
+++ b/specs/schemas/index.md
@@ -16,13 +16,48 @@ This is a _specs_ chapter, rather than a _docs_ chapter.  It's geared for in-dep
 For more introductory and human-friendly material on Schemas -- what they are, what they do, and how to use them -- see [Schemas in the docs chapters](/docs/schemas/) instead.)
 :::
 
+The Schema-Schema
+-----------------
+
 The IPLD Schema specification is self-hosting: it is primarily described by the "schema schema".
 
-- The schema-schema can be seen in two forms, in DSL form, or as the equivalent parsed Schema DMT in JSON encoding:
-	- [schema-schema.ipldsch](./schema-schema.ipldsch)
-	- [schema-schema.ipldsch.json](./schema-schema.ipldsch.json)
+The schema-schema can be seen in two forms: in DSL form, or as the equivalent parsed Schema DMT in JSON encoding:
 
-Additional material:
+- [schema-schema.ipldsch](./schema-schema.ipldsch)
+- [schema-schema.ipldsch.json](./schema-schema.ipldsch.json)
+
+### DSL vs DMT
+
+We have something called the "DSL" and something called the "DMT".  What's that stand for?
+
+- "DSL" is short for "[Domain Specific Language](https://en.wikipedia.org/wiki/Domain-specific_language)", a common term of art in computer science.
+  We mean it in the usual way: the IPLD Schema DSL is a custom, fit-for-purpose syntax for describing IPLD Schemas.
+- "DMT" is short for "[Data Model Tree](/glossary/#dmt)", and that's a term we've coined in IPLD.
+  The IPLD Schema DMT is the normalized essential form of IPLD Schemas, and use this as the interchange format and source of truth for reasoning about them.
+
+The IPLD Schema DSL can be compiled down to DMT form, and then passed around (typically, as JSON).
+(This makes it easy to build IPLD Schema tools and libraries in new languages, without having to necessarily build a DSL parser!)
+
+Note that the Schema DMT is not exactly an [AST](https://en.wikipedia.org/wiki/Abstract_syntax_tree) for the Schema DSL.
+The DMT is meant for mechanical, logical use; whereas the DSL is made for human readability and writability.
+As a result of those different priorities, they structure information in somewhat different ways.
+(The DMT is more redundant, because it insists on having type-level information be completely defined even if representation information were to be stripped,
+whereas the DSL AST avoids making the human repeat the same information twice for any reason;
+the DSL AST would probably see some representation information as adjacent to type information (e.g. next to struct fields, which is where syntactically the annotations go in that part of the DSL),
+whereas the DMT consistently specifies it all in one place under one object of representation information per type;
+etc.)
+As a user, you probably don't need to think about this, but as a library developer, keeping in mind that these are different may be a useful clarification.
+
+### The Prelude
+
+The IPLD Schema "prelude" is a series of type declarations that are implicitly present at the top of all schemas.
+It provides common types like `String` and `Map` and `List` as named types, without you needing to define them yourself.
+
+[More information about the Prelude](./prelude/)
+
+
+Examples and Fixtures
+---------------------
 
 - Examples:
 	- An example Schema, in DSL form, with matching parsed Schema DMT in JSON encoding:

--- a/specs/schemas/prelude.md
+++ b/specs/schemas/prelude.md
@@ -1,0 +1,27 @@
+The Schema Prelude
+==================
+
+The IPLD Schema "prelude" is a series of type declarations that are implicitly present at the top of all schemas.
+It introduces all the types that are seen used in nearly every schema,
+which makes them available consistently under consistent names, and saves a little redundancy for users.
+However, beyond that, there's nothing magical about the Prelude (as you'll see!).
+
+Here is the Prelude, in IPLD Schema DSL form:
+
+```ipldsch
+type Bool bool
+type Int int
+type Float float
+type String string
+type Bytes bytes
+type Any any
+type Map {String:Any}
+type List [Any]
+type Link &Any
+type Null unit representation null
+```
+
+Note that not all schemas technically need the prelude;
+it's perfectly possible to author a schema which has a name for every single one of its types,
+and doesn't use any of the names provided by the prelude.
+For example, the schema-schema happens to get along fine without ever referring to any of the types named by the prelude.

--- a/specs/schemas/prelude.md
+++ b/specs/schemas/prelude.md
@@ -21,7 +21,13 @@ type Link &Any
 type Null unit representation null
 ```
 
+### Use of the Prelude is optional
+
 Note that not all schemas technically need the prelude;
 it's perfectly possible to author a schema which has a name for every single one of its types,
 and doesn't use any of the names provided by the prelude.
-For example, the schema-schema happens to get along fine without ever referring to any of the types named by the prelude.
+It's relatively rare to see this in practice, however.
+
+For example, if we examine the schema-schema, we can see it often defines its own names for most of its types.
+However, we also see it use `String` and `Int` and `Bool` in several places;
+these type names come from the prelude.

--- a/specs/schemas/schema-schema.ipldsch
+++ b/specs/schemas/schema-schema.ipldsch
@@ -105,6 +105,8 @@ type Type union {
 	| TypeUnion "union"
 	| TypeStruct "struct"
 	| TypeEnum "enum"
+	| TypeUnit "unit"
+	| TypeAny "any"
 	| TypeCopy "copy"
 } representation inline {
 	discriminantKey "kind"
@@ -128,6 +130,8 @@ type TypeKind enum {
 	| Union ("union")
 	| Struct ("struct")
 	| Enum ("enum")
+	| Unit ("unit")
+	| Any ("any")
 }
 
 ## RepresentationKind is similar to TypeKind, but includes only those concepts
@@ -137,8 +141,9 @@ type TypeKind enum {
 ## those concepts are introduced in the IPLD Schema system, and when serialized,
 ## all of them must be transformable to one of these representation kinds
 ## (e.g. a "struct" TypeKind will usually be transformed to a "map"
-## RepresentationKind; "enum" TypeKind are always "string" RepresentationKind;
-## and so on.)
+## RepresentationKind; "enum" TypeKind are typically a "string" RepresentationKind;
+## and so on; exactly what RepresentationKind a type defintion will have
+## is determined by its representation strategy).
 ##
 ## RepresentationKind strings are sometimes used to to indicate part of the
 ## definition in the details of Type; for example, they're used describing
@@ -731,6 +736,60 @@ type EnumRepresentation_String {EnumMember:String}
 ## for each EnumMember (with `Foo ("100")`, those are stored here.
 ##
 type EnumRepresentation_Int {EnumMember:Int}
+
+## TypeUnit describes a type which contains no data at all (other than that fact of its existence).
+## (If this seems strange, consider that the cardinality of TypeBool is 2;
+## the cardinality of TypeUnit is simply 1.)
+##
+type TypeUnit struct {
+	representation UnitRepresentation
+}
+
+## UnitRepresentation is an enum for describing how a TypeUnit should be represented in the data model.
+##
+## Unit types are commonly seen represented in several ways.
+## A null token is a common one.
+## A true token is sometimes seen (especially, when people encode "sets" in json:
+## often this will be seen as a map where the values are keys and the map values are 'true').
+## Also, an empty map can be a useful unit value;
+## an empty map accurately communicates a lack of data.
+## (The emptymap strategy can be a particularly interesting choice if you want to
+## have a schema that is evolvable in the future to start using a struct or map
+## in the same place as the unit type currently stands, while having older documents
+## continue to be parsable by the evolved schema.)
+##
+## Unlike many of the other representation information types seen in the schema-schema,
+## this one is just an enum, rather than being a union.
+## That's because there's no possibility of every needing to annotate more customization
+## onto values in the unit type... because there are no possible values in the unit type.
+##
+## Note that there is no discernible logical difference between
+## `type Foo struct {}` and `type Foo unit representation emptymap`;
+## only that the latter can be said to be a more explicit description of intent.
+## Both will result in identical representations, and both have identical cardinality (which is 1).
+##
+type UnitRepresentation enum {
+	| Null ("null")
+	| True ("true")
+	| False ("false")
+	| Emptymap ("emptymap")
+}
+
+## TypeAny describes a type which can contain data of any kind.
+## It's essentially an escape valve; it says "we don't really know what lies beyond here".
+## The type-level data model kind of an "any" type can be anything;
+## it depends on what the inhabitant value is.
+## The representation-level kind can similarly be anything;
+## it will match whatever the type-level kind is.
+##
+## It is not possible to regain useful types on deeper values after using an 'any' type;
+## from then on, the rest of the data is locked in on having exactly that 'any' type,
+## and having no further ability to have separate type-level and representation-level behaviors.
+##
+## 'any' was introduced as a typekind after discovering it is not possible
+## to emulate its behavior by constructing a union; see
+## https://github.com/ipld/specs/issues/318 for some discussion of this.
+type TypeAny unit representation emptymap
 
 ## TypeCopy describes a special "copy" unit that indicates that a type name
 ## should copy the type descriptor of another type. TypeCopy does not redirect a

--- a/specs/schemas/schema-schema.ipldsch
+++ b/specs/schemas/schema-schema.ipldsch
@@ -114,20 +114,20 @@ type Type union {
 ## Notice this enum's members are the same as the set of strings used as
 ## discriminants in the Type union.
 ##
-## TODO: not actually sure we'll need to declare this.  Only usage is
-## in the Type union representation details?
+## This enum is not actually used elsewhere in the schema-schema,
+## but does correspond to the discriminant values used in the Type union.
 type TypeKind enum {
-	| Bool
-	| String
-	| Bytes
-	| Int
-	| Float
-	| Map
-	| List
-	| Link
-	| Union
-	| Struct
-	| Enum
+	| Bool ("bool")
+	| String ("string")
+	| Bytes ("bytes")
+	| Int ("int")
+	| Float ("float")
+	| Map ("map")
+	| List ("list")
+	| Link ("link")
+	| Union ("union")
+	| Struct ("struct")
+	| Enum ("enum")
 }
 
 ## RepresentationKind is similar to TypeKind, but includes only those concepts
@@ -144,14 +144,14 @@ type TypeKind enum {
 ## definition in the details of Type; for example, they're used describing
 ## some of the detailed behaviors of a "kinded"-style union type.
 type RepresentationKind enum {
-	| Bool
-	| String
-	| Bytes
-	| Int
-	| Float
-	| Map
-	| List
-	| Link
+	| Bool ("bool")
+	| String ("string")
+	| Bytes ("bytes")
+	| Int ("int")
+	| Float ("float")
+	| Map ("map")
+	| List ("list")
+	| Link ("link")
 }
 
 ## AnyScalar defines a union of the basic non-complex kinds.

--- a/specs/schemas/schema-schema.ipldsch
+++ b/specs/schemas/schema-schema.ipldsch
@@ -229,26 +229,23 @@ type TypeDefnMap struct {
 	keyType TypeName
 	valueType TypeNameOrInlineDefn
 	valueNullable Bool (implicit "false")
-	representation MapRepresentation
+	representation optional MapRepresentation
 }
 
 ## MapRepresentation describes how a map type should be mapped onto
 ## its IPLD Data Model representation.
 ##
 ## By default, a map type is also represented as a map in the Data Model,
-## but other representation strategies can be configured.
+## but other representation strategies can be configured
+##
+## Note that the `TypeDefnMap.representation` field is optional --
+## the default behavior is demarcated by the lack of any of these values.
 ##
 type MapRepresentation union {
-	| MapRepresentation_Map "map"
 	| MapRepresentation_StringPairs "stringpairs"
 	| MapRepresentation_ListPairs "listpairs"
 	| AdvancedDataLayoutName "advanced"
 } representation keyed
-
-## MapRepresentation_Map describes that a map should be encoded as
-## a map in the Data Model
-##
-type MapRepresentation_Map struct {}
 
 ## MapRepresentation_StringPairs describes that a map should be encoded as a
 ## string of delimited "k/v" entries, e.g. "k1=v1,k2=v2".
@@ -289,22 +286,19 @@ type MapRepresentation_ListPairs struct {}
 type TypeDefnList struct {
 	valueType TypeNameOrInlineDefn
 	valueNullable Bool (implicit "false")
-	representation ListRepresentation
+	representation optional ListRepresentation
 }
 
 ## ListRepresentation describes how a map type should be mapped onto
 ## its IPLD Data Model representation.  By default a list is a list in the
 ## data model but it may be replaced with an ADL.
 ##
+## Note that the `TypeDefnList.representation` field is optional --
+## the default behavior is demarcated by the lack of any of these values.
+##
 type ListRepresentation union {
-	| ListRepresentation_List "list"
 	| AdvancedDataLayoutName "advanced"
 } representation keyed
-
-## ListRepresentation_List is the default representation for TypeDefnList and
-## will be used implicitly if no representation is specified.
-##
-type ListRepresentation_List struct {}
 
 ## TypeDefnLink describes an IPLD link, which is a content-addressable pointer to more data.
 ## (Links in IPLD are implemented by CIDs: they're a hash that identifies another another block of data,

--- a/specs/schemas/schema-schema.ipldsch
+++ b/specs/schemas/schema-schema.ipldsch
@@ -3,6 +3,33 @@
 ## Yes, it's self-describing! :)
 ## -----
 
+## Schema is a the root element of an IPLD Schema document.
+##
+## A complete (if quite short) Schema might look like this:
+##
+## ```
+## {
+##   "types": {
+##     "MyFooType": {
+##       "type": "string"
+##     }
+##   }
+## }
+## ```
+##
+## The main bulk of a schema is the types map,
+## which is TypeName mapped to TypeDefn.
+##
+## Some additional top level fields are optional,
+## such as some maps which may store data about where ADLs
+## should be expected to be used within the data described by the schema.
+## However, not all schemas use these features.
+##
+type Schema struct {
+	types {TypeName:TypeDefn}
+	advanced optional AdvancedDataLayoutMap
+}
+
 ## Type names are a simple alias of string.
 ##
 ## There are some additional rules that should be applied. Type names:
@@ -16,21 +43,6 @@
 ## a TypeName must be unique within the Schema.
 ##
 type TypeName string
-
-## SchemaMap is a complete set of types;
-## it is simply a map of TypeName to the TypeDefn for that type.
-##
-## A simple schema map with one type might look like this:
-##
-## ```
-## {
-##   "MyFooType": {
-##     "string": {}
-##   }
-## }
-## ```
-##
-type SchemaMap {TypeName:TypeDefn}
 
 ## AdvancedDataLayoutName defines the name of an ADL as a string.
 ##
@@ -47,26 +59,6 @@ type AdvancedDataLayoutName string
 ## currently an empty map.
 ##
 type AdvancedDataLayoutMap {AdvancedDataLayoutName:AdvancedDataLayout}
-
-## Schema is a single-member union, which can be used in serialization
-## to make a form of "nominative type declaration".
-##
-## A complete (if quite short) Schema might look like this:
-##
-## ```
-## {
-##   "schema": {
-##     "MyFooType": {
-##       "type": "string"
-##     }
-##   }
-## }
-## ```
-##
-type Schema struct {
-	types SchemaMap
-	advanced AdvancedDataLayoutMap
-}
 
 ## TypeDefn is a union type, where each of the possible members describes one kind of type.
 ## For example, TypeDefnBool is a member of the TypeDefn union, as is TypeDefnMap.

--- a/specs/schemas/schema-schema.ipldsch
+++ b/specs/schemas/schema-schema.ipldsch
@@ -336,11 +336,8 @@ type TypeLink struct {
 ## Unions can be defined as representing in several different ways: see
 ## the documentation on the UnionRepresentation type for details.
 ##
-## The set of types which the union can contain are specified in a map
-## inside the representation field.  (The key type of the map varies per
-## representation strategy, so it's not possible to keep on this type directly.)
-##
 type TypeUnion struct {
+	members [TypeName]
 	representation UnionRepresentation
 }
 

--- a/specs/schemas/schema-schema.ipldsch
+++ b/specs/schemas/schema-schema.ipldsch
@@ -459,7 +459,9 @@ type UnionRepresentation_Inline struct {
 ## stringprefix is an invalid representation for any union that contains a type
 ## that does not have a string representation.
 ##
-type UnionRepresentation_StringPrefix {String:TypeName}
+type UnionRepresentation_StringPrefix struct {
+	prefixes {String:TypeName}
+}
 
 ## UnionRepresentation_BytesPrefix describes a union representation for unions
 ## whose member types are all bytes. It is encoded to a byte array whose
@@ -477,7 +479,9 @@ type UnionRepresentation_StringPrefix {String:TypeName}
 ## bytesprefix is an invalid representation for any union that contains a type
 ## that does not have a bytes representation.
 ##
-type UnionRepresentation_BytesPrefix {String:TypeName}
+type UnionRepresentation_BytesPrefix struct {
+	prefixes {String:TypeName}
+}
 
 ## TypeStruct describes a type which has a group of fields of varying Type.
 ## Each field has a name, which is used to access its value, similarly to

--- a/specs/schemas/schema-schema.ipldsch
+++ b/specs/schemas/schema-schema.ipldsch
@@ -701,7 +701,7 @@ type StructRepresentation_ListPairs struct {}
 ## all int values are required.
 ##
 type TypeEnum struct {
-	members {EnumMember:Null}
+	members [EnumMember]
 	representation EnumRepresentation
 }
 

--- a/specs/schemas/schema-schema.ipldsch
+++ b/specs/schemas/schema-schema.ipldsch
@@ -68,18 +68,19 @@ type Schema struct {
 	advanced AdvancedDataLayoutMap
 }
 
-## The types of Type are a union.
+## Type is a union type, where each of the possible members describes one kind of type.
+## For example, TypeBool is a member of the Type union, as is TypeMap.
 ##
-## The Type union is serialized using "inline" union representation,
-## which means all of its members have map representations, and there will be
-## an entry in that map called "type" which contains the union discriminant.
+## The Type union is serialized using "keyed" union representation,
+## which means in the serial form, we will always see a map with one key,
+## and that key will indicate which member type is coming up as the value.
 ##
 ## Some of the kinds of type are so simple the union discriminant is the only
 ## content at all, e.g. strings:
 ##
 ## ```
 ## {
-##   "type": "string"
+##   "string": {}
 ## }
 ## ```
 ##
@@ -87,9 +88,10 @@ type Schema struct {
 ##
 ## ```
 ## {
-##   "type": "map",
-##   "keyType": "String",
-##   "valueType": "Int"
+##   "map": {
+##     "keyType": "String",
+##     "valueType": "Int"
+##   }
 ## }
 ## ```
 ##
@@ -108,9 +110,7 @@ type Type union {
 	| TypeUnit "unit"
 	| TypeAny "any"
 	| TypeCopy "copy"
-} representation inline {
-	discriminantKey "kind"
-}
+} representation keyed
 
 ## TypeKind enumerates all the major kinds of type.
 ## Notice this enum's members are the same as the set of strings used as
@@ -578,8 +578,8 @@ type TypeNameOrInlineDefn union {
 ## InlineDefn also allows description of anonymous but typed links for similar reasons.
 ## TypeNameOrInlineDefn is the more complex option of the TypeTerm union.
 ##
-## Note that the representation of this union -- `representation inline "kind"`
-## -- as well as the keywords for its members -- align exactly with those
+## Note that the representation of this union -- the use of a keyed representation,
+## as well as the keywords for its members -- align exactly with those
 ## in the Type union.  Technically, this isn't a necessary property (in that
 ## nothing would break if that sameness was violated) but it's awfully nice for
 ## sanity; what we're saying here is that the representation of the types in an
@@ -590,9 +590,7 @@ type InlineDefn union {
 	| TypeMap "map"
 	| TypeList "list"
 	| TypeLink "link"
-} representation inline {
-	discriminantKey "kind"
-}
+} representation keyed
 
 ## StructRepresentation describes how a struct type should be mapped onto
 ## its IPLD Data Model representation.  Typically, maps are the representation

--- a/specs/schemas/schema-schema.ipldsch
+++ b/specs/schemas/schema-schema.ipldsch
@@ -239,8 +239,10 @@ type TypeMap struct {
 }
 
 ## MapRepresentation describes how a map type should be mapped onto
-## its IPLD Data Model representation.  By default a map is a map in the
-## Data Model but other kinds can be configured.
+## its IPLD Data Model representation.
+##
+## By default, a map type is also represented as a map in the Data Model,
+## but other representation strategies can be configured.
 ##
 type MapRepresentation union {
 	| MapRepresentation_Map "map"
@@ -334,13 +336,15 @@ type TypeLink struct {
 }
 
 ## TypeUnion describes a union (sometimes called a "sum type", or
-## more verbosely, a "discriminated union").
+## more verbosely, a "discriminated union", or in yet other literature, a "variant" type).
 ## A union is a type that can have a value of several different types, but
-## unlike maps or structs, in a union only one of those values may be present
+## unlike maps or structs, in a union, only one of those values may be present
 ## at a time.
 ##
-## Unions can be defined as representing in several different ways: see
-## the documentation on the UnionRepresentation type for details.
+## Unions can be represented in several significantly different ways:
+## see the documentation of the UnionRepresentation type for details.
+## Also note that there is no default representation for union types --
+## you must _always_ explicitly specify a representation strategy when defining unions!
 ##
 type TypeUnion struct {
 	members [UnionMember]
@@ -594,8 +598,18 @@ type InlineDefn union {
 } representation keyed
 
 ## StructRepresentation describes how a struct type should be mapped onto
-## its IPLD Data Model representation.  Typically, maps are the representation
-## kind, but other kinds and details can be configured.
+## its IPLD Data Model representation.
+##
+## The default representation strategy for struct types is a map,
+## with the struct's field names as keys.
+## However, that can be configured.
+## For example, the map representation can be configured with
+## directives to use different keys in the representation form;
+## or, configured to consider some fields as having values which should be seen as the implicit value for that field,
+## meaning the entire field shouldn't get an entry in the representation map if that value is found in that field.
+## Or, wholly different representation strategies can be used
+## (such as the tuple strategy, which results in a data model list kind,
+## or stringjoin, which results a data model string kind!).
 ##
 type StructRepresentation union {
 	| StructRepresentation_Map "map"

--- a/specs/schemas/schema-schema.ipldsch
+++ b/specs/schemas/schema-schema.ipldsch
@@ -310,26 +310,27 @@ type ListRepresentation union {
 ##
 type ListRepresentation_List struct {}
 
-## TypeLink describes a hash linking to another object (a CID).
+## TypeLink describes an IPLD link, which is a content-addressable pointer to more data.
+## (Links in IPLD are implemented by CIDs: they're a hash that identifies another another block of data,
+## plus a codec hint for how to parse it into IPLD Data Model).
 ##
-## A link also has an "expectedType" that provides a hinting mechanism
-## suggesting what we should find if we were to follow the link. This
-## cannot be strictly enforced by a node or block-level schema
-## validation but may be enforced elsewhere in an application relying on
-## a schema.
+## A typed link can optionally state an "expectedType".
+## This provides a mechanism for suggesting what we should expect find
+## if we were to follow the link.
+## (Note that this cannot be strictly enforced by a node or block-level schema validation!
+## But may be enforced elsewhere in an application using a schema, and
+## is generally enforced as soon as possible when traversing typed links.)
 ##
-## The expectedType is specified with the `&Any` link shorthand, where
-## `Any` may be replaced with a specific type.
+## In the Schema DSL, links are specified with the `&FooBar` syntax --
+## The ampersand character denotes a link, and the rest of the declaration
+## is the name of the expected type for the linked content.
 ##
-## Unlike other kinds, we use `&Type` to denote a link Type rather than
-## `Link`. In this usage, we replace `Type` the expected Type, with `&Any`
-## being shorthand for "a link which may resolve to a type of any kind".
-##
-## `expectedType` is a String, but it should validate as "Any" or a TypeName
-## found somewhere in the schema.
+## If you want the equivalent of untyped links, in the DSL, you can say `&Any`.
+## This is also available in the Prelude, and that type is simply name "Link"
+## (in other words, the Prelude contains `type Link &Any`).
 ##
 type TypeLink struct {
-	expectedType String (implicit "Any")
+	expectedType TypeName (implicit "Any")
 }
 
 ## TypeUnion describes a union (sometimes called a "sum type", or

--- a/specs/schemas/schema-schema.ipldsch
+++ b/specs/schemas/schema-schema.ipldsch
@@ -337,9 +337,28 @@ type TypeLink struct {
 ## the documentation on the UnionRepresentation type for details.
 ##
 type TypeUnion struct {
-	members [TypeName]
+	members [UnionMember]
 	representation UnionRepresentation
 }
+
+## UnionMember is a type for identifying the members of a union.
+## Most commonly, this is simply a TypeName string;
+## however, it can also be a UnionMemberInlineDefn,
+## which is used to allow inline link definitions within a kinded union as a shorthand
+## (rather than requiring all links be declared as a named type before being usable within a union).
+type UnionMember union {
+	| TypeName string
+	| UnionMemberInlineDefn map
+} representation kinded
+
+## UnionMemberInlineDefn is a very similar purpose to InlineDefn,
+## but found specifically within UnionMember.
+## It only allows describing a link type (and not maps nor lists, as InlineDefn does),
+## which is a constraint applied to union membership largely to make sure
+## if there are errors in processing unions, we can make legible messages about it!
+type UnionMemberInlineDefn union {
+	| TypeLink "link"
+} representation keyed
 
 ## UnionRepresentation is a union of all the distinct ways a TypeUnion's values
 ## can be mapped onto a serialized format for the IPLD Data Model.
@@ -378,7 +397,7 @@ type UnionRepresentation union {
 ##
 ## The referenced type must of course produce the RepresentationKind it's
 ## matched with!
-type UnionRepresentation_Kinded {RepresentationKind:TypeName}
+type UnionRepresentation_Kinded {RepresentationKind:UnionMember}
 
 ## "Keyed" union representations will encode as a map, where the map has
 ## exactly one entry, the key string of which will be used to look up the name
@@ -388,7 +407,7 @@ type UnionRepresentation_Kinded {RepresentationKind:TypeName}
 ## over the other styles wherever possible; keyed unions tend to have good
 ## performance characteristics, as they have most "mechanical sympathy" with
 ## parsing and deserialization implementation order.
-type UnionRepresentation_Keyed {String:TypeName}
+type UnionRepresentation_Keyed {String:UnionMember}
 
 ## "Envelope" union representations will encode as a map, where the map has
 ## exactly two entries: the two keys should be of the exact strings specified
@@ -399,7 +418,7 @@ type UnionRepresentation_Keyed {String:TypeName}
 type UnionRepresentation_Envelope struct {
 	discriminantKey String
 	contentKey String
-	discriminantTable {String:TypeName}
+	discriminantTable {String:UnionMember}
 }
 
 ## "Inline" union representations require that all of their members encode
@@ -538,8 +557,9 @@ type TypeNameOrInlineDefn union {
 } representation kinded
 
 ## InlineDefn represents a declaration of an anonymous type of one of the simple
-## recursive kinds (e.g. map or list) which is found "inline" in another type's
-## definition.  It's the more complex option of the TypeNameOrInlineDefn union.
+## recursive kinds (e.g. map or list) which is found "inline" in another type's definition.
+## InlineDefn also allows description of anonymous but typed links for similar reasons.
+## TypeNameOrInlineDefn is the more complex option of the TypeTerm union.
 ##
 ## Note that the representation of this union -- `representation inline "kind"`
 ## -- as well as the keywords for its members -- align exactly with those
@@ -552,6 +572,7 @@ type TypeNameOrInlineDefn union {
 type InlineDefn union {
 	| TypeMap "map"
 	| TypeList "list"
+	| TypeLink "link"
 } representation inline {
 	discriminantKey "kind"
 }

--- a/specs/schemas/schema-schema.ipldsch
+++ b/specs/schemas/schema-schema.ipldsch
@@ -664,27 +664,27 @@ type StructRepresentation_StringJoin struct {
 ##
 type StructRepresentation_ListPairs struct {}
 
-## TypeEnum describes a type which has a known, pre-defined set of possible
-## values. Each of the values must be representable as a string (EnumValue)
-## when using the default "string" representation, or when using an "int"
-## representation, an integer must also be supplied along with the EnumValue.
+## TypeEnum describes a type which has a known, pre-defined set of possible values.
+## Each of the member values is named by a string (of EnumMember type).
 ##
+## Enums can have either string or int-based representations.
 ## Integer and string values (for int and string representations respectively)
 ## are provided in parens in the DSL. Where the string used in serialization is
-## the same as the EnumValue, it may be omitted. For int representation enums,
+## the same as the EnumMember, it may be omitted. For int representation enums,
 ## all int values are required.
 ##
 type TypeEnum struct {
-	members {EnumValue:Null}
+	members {EnumMember:Null}
 	representation EnumRepresentation
 }
 
-## EnumValue is a string that has limitations for use as a member of an enum
-## set. The rules for EnumValue are the same as for TypeName but without the
-## convention of an uppercase first character. Capitalization is left up to
-## the user.
+## EnumMember is a string that that names a member of an Enum type.
 ##
-type EnumValue string
+## The range of valid values for an EnumMember are the same as for TypeName
+## but without the convention of an uppercase first character.
+## Capitalization is left up to the discretion of the schema writer.
+##
+type EnumMember string
 
 ## EnumRepresentation describes how an enum type should be mapped onto
 ## its IPLD Data Model representation. By default an enum is represented as a
@@ -696,19 +696,19 @@ type EnumRepresentation union {
 } representation keyed
 
 ## EnumRepresentation_String describes the way an enum is represented as a
-## string in the data model. By default, the strings used as EnumValue will be
+## string in the data model. By default, the strings used as EnumMember will be
 ## used at the serialization. A custom string may be provided (with `Foo ("x")`
 ## in the DSL) which will be stored here in the representation block. Missing
 ## entries in this map will use the default.
 ##
-type EnumRepresentation_String {EnumValue:String}
+type EnumRepresentation_String {EnumMember:String}
 
 ## EnumRepresentation_Int describes the way an enum is represented as an int
 ## in the data model. A mapping of names to ints is required to perform the
 ## conversion from int to enum value. In the DSL, int values _must_ be provided
-## for each EnumValue (with `Foo ("100")`, those are stored here.
+## for each EnumMember (with `Foo ("100")`, those are stored here.
 ##
-type EnumRepresentation_Int {EnumValue:Int}
+type EnumRepresentation_Int {EnumMember:Int}
 
 ## TypeCopy describes a special "copy" unit that indicates that a type name
 ## should copy the type descriptor of another type. TypeCopy does not redirect a

--- a/specs/schemas/schema-schema.ipldsch
+++ b/specs/schemas/schema-schema.ipldsch
@@ -18,19 +18,19 @@
 type TypeName string
 
 ## SchemaMap is a complete set of types;
-## it is simply a map of TypeName to detailed declaration of that Type.
+## it is simply a map of TypeName to the TypeDefn for that type.
 ##
 ## A simple schema map with one type might look like this:
 ##
 ## ```
 ## {
 ##   "MyFooType": {
-##     "type": "string"
+##     "string": {}
 ##   }
 ## }
 ## ```
 ##
-type SchemaMap {TypeName:Type}
+type SchemaMap {TypeName:TypeDefn}
 
 ## AdvancedDataLayoutName defines the name of an ADL as a string.
 ##
@@ -68,10 +68,10 @@ type Schema struct {
 	advanced AdvancedDataLayoutMap
 }
 
-## Type is a union type, where each of the possible members describes one kind of type.
-## For example, TypeBool is a member of the Type union, as is TypeMap.
+## TypeDefn is a union type, where each of the possible members describes one kind of type.
+## For example, TypeDefnBool is a member of the TypeDefn union, as is TypeDefnMap.
 ##
-## The Type union is serialized using "keyed" union representation,
+## The TypeDefn union is serialized using "keyed" union representation,
 ## which means in the serial form, we will always see a map with one key,
 ## and that key will indicate which member type is coming up as the value.
 ##
@@ -95,29 +95,31 @@ type Schema struct {
 ## }
 ## ```
 ##
-type Type union {
-	| TypeBool "bool"
-	| TypeString "string"
-	| TypeBytes "bytes"
-	| TypeInt "int"
-	| TypeFloat "float"
-	| TypeMap "map"
-	| TypeList "list"
-	| TypeLink "link"
-	| TypeUnion "union"
-	| TypeStruct "struct"
-	| TypeEnum "enum"
-	| TypeUnit "unit"
-	| TypeAny "any"
-	| TypeCopy "copy"
+type TypeDefn union {
+	| TypeDefnBool "bool"
+	| TypeDefnString "string"
+	| TypeDefnBytes "bytes"
+	| TypeDefnInt "int"
+	| TypeDefnFloat "float"
+	| TypeDefnMap "map"
+	| TypeDefnList "list"
+	| TypeDefnLink "link"
+	| TypeDefnUnion "union"
+	| TypeDefnStruct "struct"
+	| TypeDefnEnum "enum"
+	| TypeDefnUnit "unit"
+	| TypeDefnAny "any"
+	| TypeDefnCopy "copy"
 } representation keyed
 
 ## TypeKind enumerates all the major kinds of type.
 ## Notice this enum's members are the same as the set of strings used as
-## discriminants in the Type union.
+## discriminants in the TypeDefn union.
+## (Almost!  TypeDefn also contains TypeDefnCopy, which is a slight outlier.
+## (TypeDefnCopy can be used to define a type, but isn't a typekind itself.))
 ##
 ## This enum is not actually used elsewhere in the schema-schema,
-## but does correspond to the discriminant values used in the Type union.
+## but does correspond to the discriminant values used in the TypeDefn union.
 type TypeKind enum {
 	| Bool ("bool")
 	| String ("string")
@@ -146,7 +148,7 @@ type TypeKind enum {
 ## is determined by its representation strategy).
 ##
 ## RepresentationKind strings are sometimes used to to indicate part of the
-## definition in the details of Type; for example, they're used describing
+## definition in the details of TypeDefn; for example, they're used describing
 ## some of the detailed behaviors of a "kinded"-style union type.
 type RepresentationKind enum {
 	| Bool ("bool")
@@ -184,23 +186,23 @@ type AnyScalar union {
 ##
 type AdvancedDataLayout struct {}
 
-## TypeBool describes a simple boolean type.
+## TypeDefnBool describes a simple boolean type.
 ## It has no details.
 ##
-type TypeBool struct {}
+type TypeDefnBool struct {}
 
-## TypeString describes a simple string type.
+## TypeDefnString describes a simple string type.
 ## It has no details.
 ##
-type TypeString struct {}
+type TypeDefnString struct {}
 
-## TypeBytes describes a simple byte array type.
+## TypeDefnBytes describes a simple byte array type.
 ##
-type TypeBytes struct {
+type TypeDefnBytes struct {
 	representation BytesRepresentation
 }
 
-## BytesRepresentation specifies how a TypeBytes is to be serialized. By
+## BytesRepresentation specifies how a TypeDefnBytes is to be serialized. By
 ## default it will be stored as bytes in the data model but it may be replaced
 ## with an ADL.
 ##
@@ -209,29 +211,29 @@ type BytesRepresentation union {
 	| AdvancedDataLayoutName "advanced"
 } representation keyed
 
-## BytesRepresentation_Bytes is the default representation for TypeBytes and
+## BytesRepresentation_Bytes is the default representation for TypeDefnBytes and
 ## will be used implicitly if no representation is specified.
 ##
 type BytesRepresentation_Bytes struct {}
 
-## TypeInt describes a simple integer numeric type.
+## TypeDefnInt describes a simple integer numeric type.
 ## It has no details.
 ##
-type TypeInt struct {}
+type TypeDefnInt struct {}
 
-## TypeFloat describes a simple floating point numeric type.
+## TypeDefnFloat describes a simple floating point numeric type.
 ## It has no details.
 ##
-type TypeFloat struct {}
+type TypeDefnFloat struct {}
 
-## TypeMap describes a key-value map.
+## TypeDefnMap describes a key-value map.
 ## The keys and values of the map have some specific type of their own.
 ##
 ## A constraint on keyType is that the referenced type must have a string
 ## representation kind. The IPLD Data Model only allows for string keys on maps,
 ## so this constraint is imposed here.
 ##
-type TypeMap struct {
+type TypeDefnMap struct {
 	keyType TypeName
 	valueType TypeNameOrInlineDefn
 	valueNullable Bool (implicit "false")
@@ -289,10 +291,10 @@ type MapRepresentation_StringPairs struct {
 ##
 type MapRepresentation_ListPairs struct {}
 
-## TypeList describes a list.
+## TypeDefnList describes a list.
 ## The values of the list have some specific type of their own.
 ##
-type TypeList struct {
+type TypeDefnList struct {
 	valueType TypeNameOrInlineDefn
 	valueNullable Bool (implicit "false")
 	representation ListRepresentation
@@ -307,12 +309,12 @@ type ListRepresentation union {
 	| AdvancedDataLayoutName "advanced"
 } representation keyed
 
-## ListRepresentation_List is the default representation for TypeList and
+## ListRepresentation_List is the default representation for TypeDefnList and
 ## will be used implicitly if no representation is specified.
 ##
 type ListRepresentation_List struct {}
 
-## TypeLink describes an IPLD link, which is a content-addressable pointer to more data.
+## TypeDefnLink describes an IPLD link, which is a content-addressable pointer to more data.
 ## (Links in IPLD are implemented by CIDs: they're a hash that identifies another another block of data,
 ## plus a codec hint for how to parse it into IPLD Data Model).
 ##
@@ -331,11 +333,11 @@ type ListRepresentation_List struct {}
 ## This is also available in the Prelude, and that type is simply name "Link"
 ## (in other words, the Prelude contains `type Link &Any`).
 ##
-type TypeLink struct {
+type TypeDefnLink struct {
 	expectedType TypeName (implicit "Any")
 }
 
-## TypeUnion describes a union (sometimes called a "sum type", or
+## TypeDefnUnion describes a union (sometimes called a "sum type", or
 ## more verbosely, a "discriminated union", or in yet other literature, a "variant" type).
 ## A union is a type that can have a value of several different types, but
 ## unlike maps or structs, in a union, only one of those values may be present
@@ -346,7 +348,7 @@ type TypeLink struct {
 ## Also note that there is no default representation for union types --
 ## you must _always_ explicitly specify a representation strategy when defining unions!
 ##
-type TypeUnion struct {
+type TypeDefnUnion struct {
 	members [UnionMember]
 	representation UnionRepresentation
 }
@@ -367,10 +369,10 @@ type UnionMember union {
 ## which is a constraint applied to union membership largely to make sure
 ## if there are errors in processing unions, we can make legible messages about it!
 type UnionMemberInlineDefn union {
-	| TypeLink "link"
+	| TypeDefnLink "link"
 } representation keyed
 
-## UnionRepresentation is a union of all the distinct ways a TypeUnion's values
+## UnionRepresentation is a union of all the distinct ways a TypeDefnUnion's values
 ## can be mapped onto a serialized format for the IPLD Data Model.
 ##
 ## There are six strategies that can be used to encode a union:
@@ -402,7 +404,7 @@ type UnionRepresentation union {
 } representation keyed
 
 ## "Kinded" union representations describe a bidirectional mapping between
-## a RepresentationKind and a Type (referenced by name) which should be the
+## a RepresentationKind and the type which should be the
 ## union member decoded when one sees this RepresentationKind.
 ##
 ## The referenced type must of course produce the RepresentationKind it's
@@ -496,7 +498,7 @@ type UnionRepresentation_BytesPrefix struct {
 ## and consistency (and, the ability to keep the schema-schema in plain JSON!) is valuable.)
 type HexString string
 
-## TypeStruct describes a type which has a group of fields of varying Type.
+## TypeDefnStruct describes a type which has a group of fields of varying Type.
 ## Each field has a name, which is used to access its value, similarly to
 ## accessing values in a map.
 ##
@@ -505,7 +507,7 @@ type HexString string
 ## of this representation may be configured; and other representation strategies
 ## also exist).
 ##
-type TypeStruct struct {
+type TypeDefnStruct struct {
 	fields {FieldName:StructField}
 	representation StructRepresentation
 }
@@ -524,9 +526,9 @@ type TypeStruct struct {
 ##
 type FieldName string
 
-## StructField describes the properties of each field declared by a TypeStruct.
+## StructField describes the properties of each field declared by a TypeDefnStruct.
 ##
-## StructField contains properties similar to TypeMap -- namely, it describes
+## StructField contains properties similar to TypeDefnMap -- namely, it describes
 ## a content type (as a TypeNameOrInlineDefn -- it supports inline definitions) -- and
 ## has a boolean property for whether or not the value is permitted to be null.
 ##
@@ -581,20 +583,20 @@ type TypeNameOrInlineDefn union {
 ## InlineDefn represents a declaration of an anonymous type of one of the simple
 ## recursive kinds (e.g. map or list) which is found "inline" in another type's definition.
 ## InlineDefn also allows description of anonymous but typed links for similar reasons.
-## TypeNameOrInlineDefn is the more complex option of the TypeTerm union.
+## InlineDefn is the more complex option of the TypeNameOrInlineDefn union.
 ##
 ## Note that the representation of this union -- the use of a keyed representation,
 ## as well as the keywords for its members -- align exactly with those
-## in the Type union.  Technically, this isn't a necessary property (in that
+## in the TypeNameOrInlineDefn union.  Technically, this isn't a necessary property (in that
 ## nothing would break if that sameness was violated) but it's awfully nice for
 ## sanity; what we're saying here is that the representation of the types in an
-## InlineDefn should look *exactly the same* as the top-level Types... it's just
-## that we're restricted to a subset of the members.
+## InlineDefn should look *exactly the same* as the top-level type declarations...
+## it's just that within an InlineDefn, we're restricted to a subset of the members.
 ##
 type InlineDefn union {
-	| TypeMap "map"
-	| TypeList "list"
-	| TypeLink "link"
+	| TypeDefnMap "map"
+	| TypeDefnList "list"
+	| TypeDefnLink "link"
 } representation keyed
 
 ## StructRepresentation describes how a struct type should be mapped onto
@@ -716,7 +718,7 @@ type StructRepresentation_StringJoin struct {
 ##
 type StructRepresentation_ListPairs struct {}
 
-## TypeEnum describes a type which has a known, pre-defined set of possible values.
+## TypeDefnEnum describes a type which has a known, pre-defined set of possible values.
 ## Each of the member values is named by a string (of EnumMember type).
 ##
 ## Enums can have either string or int-based representations.
@@ -725,7 +727,7 @@ type StructRepresentation_ListPairs struct {}
 ## the same as the EnumMember, it may be omitted. For int representation enums,
 ## all int values are required.
 ##
-type TypeEnum struct {
+type TypeDefnEnum struct {
 	members [EnumMember]
 	representation EnumRepresentation
 }
@@ -762,15 +764,15 @@ type EnumRepresentation_String {EnumMember:String}
 ##
 type EnumRepresentation_Int {EnumMember:Int}
 
-## TypeUnit describes a type which contains no data at all (other than that fact of its existence).
-## (If this seems strange, consider that the cardinality of TypeBool is 2;
-## the cardinality of TypeUnit is simply 1.)
+## TypeDefnUnit describes a type which contains no data at all (other than that fact of its existence).
+## (If this seems strange, consider that the cardinality of a bool type is 2;
+## the cardinality of a unit type is simply 1.)
 ##
-type TypeUnit struct {
+type TypeDefnUnit struct {
 	representation UnitRepresentation
 }
 
-## UnitRepresentation is an enum for describing how a TypeUnit should be represented in the data model.
+## UnitRepresentation is an enum for describing how a TypeDefnUnit should be represented in the data model.
 ##
 ## Unit types are commonly seen represented in several ways.
 ## A null token is a common one.
@@ -800,7 +802,7 @@ type UnitRepresentation enum {
 	| Emptymap ("emptymap")
 }
 
-## TypeAny describes a type which can contain data of any kind.
+## TypeDefnAny describes a type which can contain data of any kind.
 ## It's essentially an escape valve; it says "we don't really know what lies beyond here".
 ## The type-level data model kind of an "any" type can be anything;
 ## it depends on what the inhabitant value is.
@@ -814,17 +816,17 @@ type UnitRepresentation enum {
 ## 'any' was introduced as a typekind after discovering it is not possible
 ## to emulate its behavior by constructing a union; see
 ## https://github.com/ipld/specs/issues/318 for some discussion of this.
-type TypeAny struct {}
+type TypeDefnAny struct {}
 
-## TypeCopy describes a special "copy" unit that indicates that a type name
-## should copy the type descriptor of another type. TypeCopy does not redirect a
+## TypeDefnCopy describes a special "copy" unit that indicates that a type name
+## should copy the type descriptor of another type. TypeDefnCopy does not redirect a
 ## name to another type. Instead, it copies the entire type definition and
 ## assigns it to another type.
 ##
-## The DSL defines a TypeCopy as `type NewThing = CopiedThing`, where
+## The DSL defines a TypeDefnCopy as `type NewThing = CopiedThing`, where
 ## "CopiedThing" refers to a `type` defined elsewhere in a schema and is not
 ## one of TypeKind or an inline type descriptor (`{}`, `[]`, `&`).
 ##
-type TypeCopy struct {
+type TypeDefnCopy struct {
 	fromType TypeName
 }

--- a/specs/schemas/schema-schema.ipldsch
+++ b/specs/schemas/schema-schema.ipldsch
@@ -789,7 +789,7 @@ type UnitRepresentation enum {
 ## 'any' was introduced as a typekind after discovering it is not possible
 ## to emulate its behavior by constructing a union; see
 ## https://github.com/ipld/specs/issues/318 for some discussion of this.
-type TypeAny unit representation emptymap
+type TypeAny struct {}
 
 ## TypeCopy describes a special "copy" unit that indicates that a type name
 ## should copy the type descriptor of another type. TypeCopy does not redirect a

--- a/specs/schemas/schema-schema.ipldsch
+++ b/specs/schemas/schema-schema.ipldsch
@@ -228,7 +228,7 @@ type TypeFloat struct {}
 ##
 type TypeMap struct {
 	keyType TypeName
-	valueType TypeTerm
+	valueType TypeNameOrInlineDefn
 	valueNullable Bool (implicit "false")
 	representation MapRepresentation
 }
@@ -286,7 +286,7 @@ type MapRepresentation_ListPairs struct {}
 ## The values of the list have some specific type of their own.
 ##
 type TypeList struct {
-	valueType TypeTerm
+	valueType TypeNameOrInlineDefn
 	valueNullable Bool (implicit "false")
 	representation ListRepresentation
 }
@@ -486,7 +486,7 @@ type FieldName string
 ## StructField describes the properties of each field declared by a TypeStruct.
 ##
 ## StructField contains properties similar to TypeMap -- namely, it describes
-## a content type (as a TypeTerm -- it supports inline definitions) -- and
+## a content type (as a TypeNameOrInlineDefn -- it supports inline definitions) -- and
 ## has a boolean property for whether or not the value is permitted to be null.
 ##
 ## In addition, StructField also has a property called "optional".
@@ -512,33 +512,34 @@ type FieldName string
 ## just like "nullable" fields; "implicit" fields *do not*.
 ##
 type StructField struct {
-	type TypeTerm
+	type TypeNameOrInlineDefn
 	optional Bool (implicit "false")
 	nullable Bool (implicit "false")
 }
 
-## TypeTerm is a union of either TypeName or an InlineDefn. th It's used for the
-## value type in the recursive types (maps, lists, and the fields of structs),
+## TypeNameOrInlineDefn is a union of either TypeName or an InlineDefn.
+## It's used for the value type in the recursive types (maps, lists, and the fields of structs),
 ## which allows the use of InlineDefn in any of those positions.
 ##
-## TypeTerm is simply a TypeName if the kind of data is a string; this is the
-## simple case.
+## TypeNameOrInlineDefn is simply a TypeName if the kind of data is a string;
+## this is simple and common case.
+## If the data is a map, then it requires further recognition as an InlineDefn.
 ##
-## Note that TypeTerm isn't used to describe *keys* in the recursive types that
+## Note that TypeNameOrInlineDefn isn't used to describe *keys* in the recursive types that
 ## have them (maps, structs) -- recursive types in keys would not lend itself
 ## well to serialization!
-## TypeTerm also isn't used to describe members in Unions -- this is a choice
+## TypeNameOrInlineDefn also isn't used to describe members in Unions -- this is a choice
 ## aimed to limit syntactical complexity (both at type definition authoring
 ## time, as well as for the sake of error messaging during typechecking).
 ##
-type TypeTerm union {
+type TypeNameOrInlineDefn union {
 	| TypeName string
 	| InlineDefn map
 } representation kinded
 
 ## InlineDefn represents a declaration of an anonymous type of one of the simple
 ## recursive kinds (e.g. map or list) which is found "inline" in another type's
-## definition.  It's the more complex option of the TypeTerm union.
+## definition.  It's the more complex option of the TypeNameOrInlineDefn union.
 ##
 ## Note that the representation of this union -- `representation inline "kind"`
 ## -- as well as the keywords for its members -- align exactly with those

--- a/specs/schemas/schema-schema.ipldsch
+++ b/specs/schemas/schema-schema.ipldsch
@@ -480,8 +480,16 @@ type UnionRepresentation_StringPrefix struct {
 ## that does not have a bytes representation.
 ##
 type UnionRepresentation_BytesPrefix struct {
-	prefixes {String:TypeName}
+	prefixes {HexString:TypeName}
 }
+
+## HexString is an alias for string, to denote and clarify that it's not a regular freetext string.
+## It's seen used in the UnionRepresentation_BytesPrefix type.
+##
+## (We use hexadecimal strings in the schema-schema in some places,
+## even though we could've used bytes types, because the schema DSL also uses hex strings,
+## and consistency (and, the ability to keep the schema-schema in plain JSON!) is valuable.)
+type HexString string
 
 ## TypeStruct describes a type which has a group of fields of varying Type.
 ## Each field has a name, which is used to access its value, similarly to

--- a/specs/schemas/schema-schema.ipldsch.json
+++ b/specs/schemas/schema-schema.ipldsch.json
@@ -72,21 +72,21 @@
 		},
 		"TypeKind": {
 			"kind": "enum",
-			"members": {
-				"Bool": null,
-				"String": null,
-				"Bytes": null,
-				"Int": null,
-				"Float": null,
-				"Map": null,
-				"List": null,
-				"Link": null,
-				"Union": null,
-				"Struct": null,
-				"Enum": null,
-				"Unit": null,
-				"Any": null
-			},
+			"members": [
+				"Bool",
+				"String",
+				"Bytes",
+				"Int",
+				"Float",
+				"Map",
+				"List",
+				"Link",
+				"Union",
+				"Struct",
+				"Enum",
+				"Unit",
+				"Any"
+			],
 			"representation": {
 				"string": {
 					"Bool": "bool",
@@ -107,16 +107,16 @@
 		},
 		"RepresentationKind": {
 			"kind": "enum",
-			"members": {
-				"Bool": null,
-				"String": null,
-				"Bytes": null,
-				"Int": null,
-				"Float": null,
-				"Map": null,
-				"List": null,
-				"Link": null
-			},
+			"members": [
+				"Bool",
+				"String",
+				"Bytes",
+				"Int",
+				"Float",
+				"Map",
+				"List",
+				"Link"
+			],
 			"representation": {
 				"string": {
 					"Bool": "bool",
@@ -655,9 +655,8 @@
 			"fields": {
 				"members": {
 					"type": {
-						"kind": "map",
-						"keyType": "EnumMember",
-						"valueType": "Null"
+						"kind": "list",
+						"valueType": "EnumMember"
 					}
 				},
 				"representation": {
@@ -707,12 +706,12 @@
 		},
 		"UnitRepresentation": {
 			"kind": "enum",
-			"members": {
-				"Null": null,
-				"True": null,
-				"False": null,
-				"Emptymap": null
-			},
+			"members": [
+				"Null",
+				"True",
+				"False",
+				"Emptymap"
+			],
 			"representation": {
 				"string": {
 					"Null": "null",

--- a/specs/schemas/schema-schema.ipldsch.json
+++ b/specs/schemas/schema-schema.ipldsch.json
@@ -356,7 +356,7 @@
 			"struct": {
 				"fields": {
 					"expectedType": {
-						"type": "String"
+						"type": "TypeName"
 					}
 				},
 				"representation": {

--- a/specs/schemas/schema-schema.ipldsch.json
+++ b/specs/schemas/schema-schema.ipldsch.json
@@ -1,28 +1,15 @@
 {
 	"types": {
-		"TypeName": {
-			"string": {}
-		},
-		"SchemaMap": {
-			"map": {
-				"keyType": "TypeName",
-				"valueType": "TypeDefn"
-			}
-		},
-		"AdvancedDataLayoutName": {
-			"string": {}
-		},
-		"AdvancedDataLayoutMap": {
-			"map": {
-				"keyType": "AdvancedDataLayoutName",
-				"valueType": "AdvancedDataLayout"
-			}
-		},
 		"Schema": {
 			"struct": {
 				"fields": {
 					"types": {
-						"type": "SchemaMap"
+						"type": {
+							"map": {
+								"keyType": "TypeName",
+								"valueType": "TypeDefn"
+							}
+						}
 					},
 					"advanced": {
 						"type": "AdvancedDataLayoutMap"
@@ -31,6 +18,18 @@
 				"representation": {
 					"map": {}
 				}
+			}
+		},
+		"TypeName": {
+			"string": {}
+		},
+		"AdvancedDataLayoutName": {
+			"string": {}
+		},
+		"AdvancedDataLayoutMap": {
+			"map": {
+				"keyType": "AdvancedDataLayoutName",
+				"valueType": "AdvancedDataLayout"
 			}
 		},
 		"TypeDefn": {

--- a/specs/schemas/schema-schema.ipldsch.json
+++ b/specs/schemas/schema-schema.ipldsch.json
@@ -214,7 +214,7 @@
 					"type": "TypeName"
 				},
 				"valueType": {
-					"type": "TypeTerm"
+					"type": "TypeNameOrInlineDefn"
 				},
 				"valueNullable": {
 					"type": "Bool"
@@ -282,7 +282,7 @@
 			"kind": "struct",
 			"fields": {
 				"valueType": {
-					"type": "TypeTerm"
+					"type": "TypeNameOrInlineDefn"
 				},
 				"valueNullable": {
 					"type": "Bool"
@@ -460,7 +460,7 @@
 			"kind": "struct",
 			"fields": {
 				"type": {
-					"type": "TypeTerm"
+					"type": "TypeNameOrInlineDefn"
 				},
 				"optional": {
 					"type": "Bool"
@@ -482,7 +482,7 @@
 				}
 			}
 		},
-		"TypeTerm": {
+		"TypeNameOrInlineDefn": {
 			"kind": "union",
 			"members": [
 				"TypeName",

--- a/specs/schemas/schema-schema.ipldsch.json
+++ b/specs/schemas/schema-schema.ipldsch.json
@@ -1,761 +1,824 @@
 {
 	"types": {
 		"TypeName": {
-			"kind": "string"
+			"string": {}
 		},
 		"SchemaMap": {
-			"kind": "map",
-			"keyType": "TypeName",
-			"valueType": "Type"
+			"map": {
+				"keyType": "TypeName",
+				"valueType": "Type"
+			}
 		},
 		"AdvancedDataLayoutName": {
-			"kind": "string"
+			"string": {}
 		},
 		"AdvancedDataLayoutMap": {
-			"kind": "map",
-			"keyType": "AdvancedDataLayoutName",
-			"valueType": "AdvancedDataLayout"
+			"map": {
+				"keyType": "AdvancedDataLayoutName",
+				"valueType": "AdvancedDataLayout"
+			}
 		},
 		"Schema": {
-			"kind": "struct",
-			"fields": {
-				"types": {
-					"type": "SchemaMap"
+			"struct": {
+				"fields": {
+					"types": {
+						"type": "SchemaMap"
+					},
+					"advanced": {
+						"type": "AdvancedDataLayoutMap"
+					}
 				},
-				"advanced": {
-					"type": "AdvancedDataLayoutMap"
+				"representation": {
+					"map": {}
 				}
-			},
-			"representation": {
-				"map": {}
 			}
 		},
 		"Type": {
-			"kind": "union",
-			"members": [
-				"TypeBool",
-				"TypeString",
-				"TypeBytes",
-				"TypeInt",
-				"TypeFloat",
-				"TypeMap",
-				"TypeList",
-				"TypeLink",
-				"TypeUnion",
-				"TypeStruct",
-				"TypeEnum",
-				"TypeUnit",
-				"TypeAny",
-				"TypeCopy"
-			],
-			"representation": {
-				"inline": {
-					"discriminantKey": "kind",
-					"discriminantTable": {
-						"bool": "TypeBool",
-						"string": "TypeString",
-						"bytes": "TypeBytes",
-						"int": "TypeInt",
-						"float": "TypeFloat",
-						"map": "TypeMap",
-						"list": "TypeList",
-						"link": "TypeLink",
-						"union": "TypeUnion",
-						"struct": "TypeStruct",
-						"enum": "TypeEnum",
-						"unit": "TypeUnit",
-						"any": "TypeAny",
-						"copy": "TypeCopy"
+			"union": {
+				"members": [
+					"TypeBool",
+					"TypeString",
+					"TypeBytes",
+					"TypeInt",
+					"TypeFloat",
+					"TypeMap",
+					"TypeList",
+					"TypeLink",
+					"TypeUnion",
+					"TypeStruct",
+					"TypeEnum",
+					"TypeUnit",
+					"TypeAny",
+					"TypeCopy"
+				],
+				"representation": {
+					"inline": {
+						"discriminantKey": "kind",
+						"discriminantTable": {
+							"bool": "TypeBool",
+							"string": "TypeString",
+							"bytes": "TypeBytes",
+							"int": "TypeInt",
+							"float": "TypeFloat",
+							"map": "TypeMap",
+							"list": "TypeList",
+							"link": "TypeLink",
+							"union": "TypeUnion",
+							"struct": "TypeStruct",
+							"enum": "TypeEnum",
+							"unit": "TypeUnit",
+							"any": "TypeAny",
+							"copy": "TypeCopy"
+						}
 					}
 				}
 			}
 		},
 		"TypeKind": {
-			"kind": "enum",
-			"members": [
-				"Bool",
-				"String",
-				"Bytes",
-				"Int",
-				"Float",
-				"Map",
-				"List",
-				"Link",
-				"Union",
-				"Struct",
-				"Enum",
-				"Unit",
-				"Any"
-			],
-			"representation": {
-				"string": {
-					"Bool": "bool",
-					"String": "string",
-					"Bytes": "bytes",
-					"Int": "int",
-					"Float": "float",
-					"Map": "map",
-					"List": "list",
-					"Link": "link",
-					"Union": "union",
-					"Struct": "struct",
-					"Enum": "enum",
-					"Unit": "unit",
-					"Any": "any"
+			"enum": {
+				"members": [
+					"Bool",
+					"String",
+					"Bytes",
+					"Int",
+					"Float",
+					"Map",
+					"List",
+					"Link",
+					"Union",
+					"Struct",
+					"Enum",
+					"Unit",
+					"Any"
+				],
+				"representation": {
+					"string": {
+						"Bool": "bool",
+						"String": "string",
+						"Bytes": "bytes",
+						"Int": "int",
+						"Float": "float",
+						"Map": "map",
+						"List": "list",
+						"Link": "link",
+						"Union": "union",
+						"Struct": "struct",
+						"Enum": "enum",
+						"Unit": "unit",
+						"Any": "any"
+					}
 				}
 			}
 		},
 		"RepresentationKind": {
-			"kind": "enum",
-			"members": [
-				"Bool",
-				"String",
-				"Bytes",
-				"Int",
-				"Float",
-				"Map",
-				"List",
-				"Link"
-			],
-			"representation": {
-				"string": {
-					"Bool": "bool",
-					"String": "string",
-					"Bytes": "bytes",
-					"Int": "int",
-					"Float": "float",
-					"Map": "map",
-					"List": "list",
-					"Link": "link"
+			"enum": {
+				"members": [
+					"Bool",
+					"String",
+					"Bytes",
+					"Int",
+					"Float",
+					"Map",
+					"List",
+					"Link"
+				],
+				"representation": {
+					"string": {
+						"Bool": "bool",
+						"String": "string",
+						"Bytes": "bytes",
+						"Int": "int",
+						"Float": "float",
+						"Map": "map",
+						"List": "list",
+						"Link": "link"
+					}
 				}
 			}
 		},
 		"AnyScalar": {
-			"kind": "union",
-			"members": [
-				"Bool",
-				"String",
-				"Bytes",
-				"Int",
-				"Float"
-			],
-			"representation": {
-				"kinded": {
-					"bool": "Bool",
-					"string": "String",
-					"bytes": "Bytes",
-					"int": "Int",
-					"float": "Float"
+			"union": {
+				"members": [
+					"Bool",
+					"String",
+					"Bytes",
+					"Int",
+					"Float"
+				],
+				"representation": {
+					"kinded": {
+						"bool": "Bool",
+						"string": "String",
+						"bytes": "Bytes",
+						"int": "Int",
+						"float": "Float"
+					}
 				}
 			}
 		},
 		"AdvancedDataLayout": {
-			"kind": "struct",
-			"fields": {},
-			"representation": {
-				"map": {}
+			"struct": {
+				"fields": {},
+				"representation": {
+					"map": {}
+				}
 			}
 		},
 		"TypeBool": {
-			"kind": "struct",
-			"fields": {},
-			"representation": {
-				"map": {}
+			"struct": {
+				"fields": {},
+				"representation": {
+					"map": {}
+				}
 			}
 		},
 		"TypeString": {
-			"kind": "struct",
-			"fields": {},
-			"representation": {
-				"map": {}
+			"struct": {
+				"fields": {},
+				"representation": {
+					"map": {}
+				}
 			}
 		},
 		"TypeBytes": {
-			"kind": "struct",
-			"fields": {
+			"struct": {
+				"fields": {
+					"representation": {
+						"type": "BytesRepresentation"
+					}
+				},
 				"representation": {
-					"type": "BytesRepresentation"
+					"map": {}
 				}
-			},
-			"representation": {
-				"map": {}
 			}
 		},
 		"BytesRepresentation": {
-			"kind": "union",
-			"members": [
-				"BytesRepresentation_Bytes",
-				"AdvancedDataLayoutName"
-			],
-			"representation": {
-				"keyed": {
-					"bytes": "BytesRepresentation_Bytes",
-					"advanced": "AdvancedDataLayoutName"
+			"union": {
+				"members": [
+					"BytesRepresentation_Bytes",
+					"AdvancedDataLayoutName"
+				],
+				"representation": {
+					"keyed": {
+						"bytes": "BytesRepresentation_Bytes",
+						"advanced": "AdvancedDataLayoutName"
+					}
 				}
 			}
 		},
 		"BytesRepresentation_Bytes": {
-			"kind": "struct",
-			"fields": {},
-			"representation": {
-				"map": {}
+			"struct": {
+				"fields": {},
+				"representation": {
+					"map": {}
+				}
 			}
 		},
 		"TypeInt": {
-			"kind": "struct",
-			"fields": {},
-			"representation": {
-				"map": {}
+			"struct": {
+				"fields": {},
+				"representation": {
+					"map": {}
+				}
 			}
 		},
 		"TypeFloat": {
-			"kind": "struct",
-			"fields": {},
-			"representation": {
-				"map": {}
+			"struct": {
+				"fields": {},
+				"representation": {
+					"map": {}
+				}
 			}
 		},
 		"TypeMap": {
-			"kind": "struct",
-			"fields": {
-				"keyType": {
-					"type": "TypeName"
-				},
-				"valueType": {
-					"type": "TypeNameOrInlineDefn"
-				},
-				"valueNullable": {
-					"type": "Bool"
+			"struct": {
+				"fields": {
+					"keyType": {
+						"type": "TypeName"
+					},
+					"valueType": {
+						"type": "TypeNameOrInlineDefn"
+					},
+					"valueNullable": {
+						"type": "Bool"
+					},
+					"representation": {
+						"type": "MapRepresentation"
+					}
 				},
 				"representation": {
-					"type": "MapRepresentation"
-				}
-			},
-			"representation": {
-				"map": {
-					"fields": {
-						"valueNullable": {
-							"implicit": false
+					"map": {
+						"fields": {
+							"valueNullable": {
+								"implicit": false
+							}
 						}
 					}
 				}
 			}
 		},
 		"MapRepresentation": {
-			"kind": "union",
-			"members": [
-				"MapRepresentation_Map",
-				"MapRepresentation_StringPairs",
-				"MapRepresentation_ListPairs",
-				"AdvancedDataLayoutName"
-			],
-			"representation": {
-				"keyed": {
-					"map": "MapRepresentation_Map",
-					"stringpairs": "MapRepresentation_StringPairs",
-					"listpairs": "MapRepresentation_ListPairs",
-					"advanced": "AdvancedDataLayoutName"
+			"union": {
+				"members": [
+					"MapRepresentation_Map",
+					"MapRepresentation_StringPairs",
+					"MapRepresentation_ListPairs",
+					"AdvancedDataLayoutName"
+				],
+				"representation": {
+					"keyed": {
+						"map": "MapRepresentation_Map",
+						"stringpairs": "MapRepresentation_StringPairs",
+						"listpairs": "MapRepresentation_ListPairs",
+						"advanced": "AdvancedDataLayoutName"
+					}
 				}
 			}
 		},
 		"MapRepresentation_Map": {
-			"kind": "struct",
-			"fields": {},
-			"representation": {
-				"map": {}
+			"struct": {
+				"fields": {},
+				"representation": {
+					"map": {}
+				}
 			}
 		},
 		"MapRepresentation_StringPairs": {
-			"kind": "struct",
-			"fields": {
-				"innerDelim": {
-					"type": "String"
+			"struct": {
+				"fields": {
+					"innerDelim": {
+						"type": "String"
+					},
+					"entryDelim": {
+						"type": "String"
+					}
 				},
-				"entryDelim": {
-					"type": "String"
+				"representation": {
+					"map": {}
 				}
-			},
-			"representation": {
-				"map": {}
 			}
 		},
 		"MapRepresentation_ListPairs": {
-			"kind": "struct",
-			"fields": {},
-			"representation": {
-				"map": {}
+			"struct": {
+				"fields": {},
+				"representation": {
+					"map": {}
+				}
 			}
 		},
 		"TypeList": {
-			"kind": "struct",
-			"fields": {
-				"valueType": {
-					"type": "TypeNameOrInlineDefn"
-				},
-				"valueNullable": {
-					"type": "Bool"
+			"struct": {
+				"fields": {
+					"valueType": {
+						"type": "TypeNameOrInlineDefn"
+					},
+					"valueNullable": {
+						"type": "Bool"
+					},
+					"representation": {
+						"type": "ListRepresentation"
+					}
 				},
 				"representation": {
-					"type": "ListRepresentation"
-				}
-			},
-			"representation": {
-				"map": {
-					"fields": {
-						"valueNullable": {
-							"implicit": false
+					"map": {
+						"fields": {
+							"valueNullable": {
+								"implicit": false
+							}
 						}
 					}
 				}
 			}
 		},
 		"ListRepresentation": {
-			"kind": "union",
-			"members": [
-				"ListRepresentation_List",
-				"AdvancedDataLayoutName"
-			],
-			"representation": {
-				"keyed": {
-					"list": "ListRepresentation_List",
-					"advanced": "AdvancedDataLayoutName"
+			"union": {
+				"members": [
+					"ListRepresentation_List",
+					"AdvancedDataLayoutName"
+				],
+				"representation": {
+					"keyed": {
+						"list": "ListRepresentation_List",
+						"advanced": "AdvancedDataLayoutName"
+					}
 				}
 			}
 		},
 		"ListRepresentation_List": {
-			"kind": "struct",
-			"fields": {},
-			"representation": {
-				"map": {}
+			"struct": {
+				"fields": {},
+				"representation": {
+					"map": {}
+				}
 			}
 		},
 		"TypeLink": {
-			"kind": "struct",
-			"fields": {
-				"expectedType": {
-					"type": "String"
-				}
-			},
-			"representation": {
-				"map": {
-					"fields": {
-						"expectedType": {
-							"implicit": "Any"
+			"struct": {
+				"fields": {
+					"expectedType": {
+						"type": "String"
+					}
+				},
+				"representation": {
+					"map": {
+						"fields": {
+							"expectedType": {
+								"implicit": "Any"
+							}
 						}
 					}
 				}
 			}
 		},
 		"TypeUnion": {
-			"kind": "struct",
-			"fields": {
-				"members": {
-					"type": {
-						"kind": "list",
-						"valueType": "UnionMember"
+			"struct": {
+				"fields": {
+					"members": {
+						"type": {
+							"list": {
+								"valueType": "UnionMember"
+							}
+						}
+					},
+					"representation": {
+						"type": "UnionRepresentation"
 					}
 				},
 				"representation": {
-					"type": "UnionRepresentation"
+					"map": {}
 				}
-			},
-			"representation": {
-				"map": {}
 			}
 		},
 		"UnionMember": {
-			"kind": "union",
-			"members": [
-				"TypeName",
-				"UnionMemberInlineDefn"
-			],
-			"representation": {
-				"kinded": {
-					"string": "TypeName",
-					"map": "UnionMemberInlineDefn"
+			"union": {
+				"members": [
+					"TypeName",
+					"UnionMemberInlineDefn"
+				],
+				"representation": {
+					"kinded": {
+						"string": "TypeName",
+						"map": "UnionMemberInlineDefn"
+					}
 				}
 			}
 		},
 		"UnionMemberInlineDefn": {
-			"kind": "union",
-			"members": [
-				"TypeLink"
-			],
-			"representation": {
-				"keyed": {
-					"link": "TypeLink"
+			"union": {
+				"members": [
+					"TypeLink"
+				],
+				"representation": {
+					"keyed": {
+						"link": "TypeLink"
+					}
 				}
 			}
 		},
 		"UnionRepresentation": {
-			"kind": "union",
-			"members": [
-				"UnionRepresentation_Kinded",
-				"UnionRepresentation_Keyed",
-				"UnionRepresentation_Envelope",
-				"UnionRepresentation_Inline",
-				"UnionRepresentation_StringPrefix",
-				"UnionRepresentation_BytesPrefix"
-			],
-			"representation": {
-				"keyed": {
-					"kinded": "UnionRepresentation_Kinded",
-					"keyed": "UnionRepresentation_Keyed",
-					"envelope": "UnionRepresentation_Envelope",
-					"inline": "UnionRepresentation_Inline",
-					"stringprefix": "UnionRepresentation_StringPrefix",
-					"bytesprefix": "UnionRepresentation_BytesPrefix"
+			"union": {
+				"members": [
+					"UnionRepresentation_Kinded",
+					"UnionRepresentation_Keyed",
+					"UnionRepresentation_Envelope",
+					"UnionRepresentation_Inline",
+					"UnionRepresentation_StringPrefix",
+					"UnionRepresentation_BytesPrefix"
+				],
+				"representation": {
+					"keyed": {
+						"kinded": "UnionRepresentation_Kinded",
+						"keyed": "UnionRepresentation_Keyed",
+						"envelope": "UnionRepresentation_Envelope",
+						"inline": "UnionRepresentation_Inline",
+						"stringprefix": "UnionRepresentation_StringPrefix",
+						"bytesprefix": "UnionRepresentation_BytesPrefix"
+					}
 				}
 			}
 		},
 		"UnionRepresentation_Kinded": {
-			"kind": "map",
-			"keyType": "RepresentationKind",
-			"valueType": "UnionMember"
+			"map": {
+				"keyType": "RepresentationKind",
+				"valueType": "UnionMember"
+			}
 		},
 		"UnionRepresentation_Keyed": {
-			"kind": "map",
-			"keyType": "String",
-			"valueType": "UnionMember"
+			"map": {
+				"keyType": "String",
+				"valueType": "UnionMember"
+			}
 		},
 		"UnionRepresentation_Envelope": {
-			"kind": "struct",
-			"fields": {
-				"discriminantKey": {
-					"type": "String"
-				},
-				"contentKey": {
-					"type": "String"
-				},
-				"discriminantTable": {
-					"type": {
-						"kind": "map",
-						"keyType": "String",
-						"valueType": "UnionMember"
-					}
-				}
-			},
-			"representation": {
-				"map": {}
-			}
-		},
-		"UnionRepresentation_Inline": {
-			"kind": "struct",
-			"fields": {
-				"discriminantKey": {
-					"type": "String"
-				},
-				"discriminantTable": {
-					"type": {
-						"kind": "map",
-						"keyType": "String",
-						"valueType": "TypeName"
-					}
-				}
-			},
-			"representation": {
-				"map": {}
-			}
-		},
-		"UnionRepresentation_StringPrefix": {
-			"kind": "struct",
-			"fields": {
-				"prefixes": {
-					"kind": "map",
-					"keyType": "String",
-					"valueType": "TypeName"
-				}
-			},
-			"representation": {
-				"map": {}
-			}
-		},
-		"UnionRepresentation_BytesPrefix": {
-			"kind": "struct",
-			"fields": {
-				"prefixes": {
-					"kind": "map",
-					"keyType": "HexString",
-					"valueType": "TypeName"
-				}
-			},
-			"representation": {
-				"map": {}
-			}
-		},
-		"HexString": {
-			"kind": "string"
-		},
-		"TypeStruct": {
-			"kind": "struct",
-			"fields": {
+			"struct": {
 				"fields": {
-					"type": {
-						"kind": "map",
-						"keyType": "FieldName",
-						"valueType": "StructField"
+					"discriminantKey": {
+						"type": "String"
+					},
+					"contentKey": {
+						"type": "String"
+					},
+					"discriminantTable": {
+						"type": {
+							"map": {
+								"keyType": "String",
+								"valueType": "UnionMember"
+							}
+						}
 					}
 				},
 				"representation": {
-					"type": "StructRepresentation"
+					"map": {}
 				}
-			},
-			"representation": {
-				"map": {}
+			}
+		},
+		"UnionRepresentation_Inline": {
+			"struct": {
+				"fields": {
+					"discriminantKey": {
+						"type": "String"
+					},
+					"discriminantTable": {
+						"type": {
+							"map": {
+								"keyType": "String",
+								"valueType": "TypeName"
+							}
+						}
+					}
+				},
+				"representation": {
+					"map": {}
+				}
+			}
+		},
+		"UnionRepresentation_StringPrefix": {
+			"struct": {
+				"fields": {
+					"prefixes": {
+						"map": {
+							"keyType": "String",
+							"valueType": "TypeName"
+						}
+					}
+				},
+				"representation": {
+					"map": {}
+				}
+			}
+		},
+		"UnionRepresentation_BytesPrefix": {
+			"struct": {
+				"fields": {
+					"prefixes": {
+						"map": {
+							"keyType": "HexString",
+							"valueType": "TypeName"
+						}
+					}
+				},
+				"representation": {
+					"map": {}
+				}
+			}
+		},
+		"HexString": {
+			"string": {}
+		},
+		"TypeStruct": {
+			"struct": {
+				"fields": {
+					"fields": {
+						"type": {
+							"map": {
+								"keyType": "FieldName",
+								"valueType": "StructField"
+							}
+						}
+					},
+					"representation": {
+						"type": "StructRepresentation"
+					}
+				},
+				"representation": {
+					"map": {}
+				}
 			}
 		},
 		"FieldName": {
-			"kind": "string"
+			"string": {}
 		},
 		"StructField": {
-			"kind": "struct",
-			"fields": {
-				"type": {
-					"type": "TypeNameOrInlineDefn"
+			"struct": {
+				"fields": {
+					"type": {
+						"type": "TypeNameOrInlineDefn"
+					},
+					"optional": {
+						"type": "Bool"
+					},
+					"nullable": {
+						"type": "Bool"
+					}
 				},
-				"optional": {
-					"type": "Bool"
-				},
-				"nullable": {
-					"type": "Bool"
-				}
-			},
-			"representation": {
-				"map": {
-					"fields": {
-						"optional": {
-							"implicit": false
-						},
-						"nullable": {
-							"implicit": false
+				"representation": {
+					"map": {
+						"fields": {
+							"optional": {
+								"implicit": false
+							},
+							"nullable": {
+								"implicit": false
+							}
 						}
 					}
 				}
 			}
 		},
 		"TypeNameOrInlineDefn": {
-			"kind": "union",
-			"members": [
-				"TypeName",
-				"InlineDefn"
-			],
-			"representation": {
-				"kinded": {
-					"string": "TypeName",
-					"map": "InlineDefn"
+			"union": {
+				"members": [
+					"TypeName",
+					"InlineDefn"
+				],
+				"representation": {
+					"kinded": {
+						"string": "TypeName",
+						"map": "InlineDefn"
+					}
 				}
 			}
 		},
 		"InlineDefn": {
-			"kind": "union",
-			"members": [
-				"TypeMap",
-				"TypeList",
-				"TypeLink"
-			],
-			"representation": {
-				"inline": {
-					"discriminantKey": "kind",
-					"discriminantTable": {
-						"map": "TypeMap",
-						"list": "TypeList",
-						"link": "TypeLink"
+			"union": {
+				"members": [
+					"TypeMap",
+					"TypeList",
+					"TypeLink"
+				],
+				"representation": {
+					"inline": {
+						"discriminantKey": "kind",
+						"discriminantTable": {
+							"map": "TypeMap",
+							"list": "TypeList",
+							"link": "TypeLink"
+						}
 					}
 				}
 			}
 		},
 		"StructRepresentation": {
-			"kind": "union",
-			"members": [
-				"StructRepresentation_Map",
-				"StructRepresentation_Tuple",
-				"StructRepresentation_StringPairs",
-				"StructRepresentation_StringJoin",
-				"StructRepresentation_ListPairs"
-			],
-			"representation": {
-				"keyed": {
-					"map": "StructRepresentation_Map",
-					"tuple": "StructRepresentation_Tuple",
-					"stringpairs": "StructRepresentation_StringPairs",
-					"stringjoin": "StructRepresentation_StringJoin",
-					"listpairs": "StructRepresentation_ListPairs"
+			"union": {
+				"members": [
+					"StructRepresentation_Map",
+					"StructRepresentation_Tuple",
+					"StructRepresentation_StringPairs",
+					"StructRepresentation_StringJoin",
+					"StructRepresentation_ListPairs"
+				],
+				"representation": {
+					"keyed": {
+						"map": "StructRepresentation_Map",
+						"tuple": "StructRepresentation_Tuple",
+						"stringpairs": "StructRepresentation_StringPairs",
+						"stringjoin": "StructRepresentation_StringJoin",
+						"listpairs": "StructRepresentation_ListPairs"
+					}
 				}
 			}
 		},
 		"StructRepresentation_Map": {
-			"kind": "struct",
-			"fields": {
+			"struct": {
 				"fields": {
-					"type": {
-						"kind": "map",
-						"keyType": "FieldName",
-						"valueType": "StructRepresentation_Map_FieldDetails"
-					},
-					"optional": true
-				}
-			},
-			"representation": {
-				"map": {}
-			}
-		},
-		"StructRepresentation_Map_FieldDetails": {
-			"kind": "struct",
-			"fields": {
-				"rename": {
-					"type": "String",
-					"optional": true
-				},
-				"implicit": {
-					"type": "AnyScalar",
-					"optional": true
-				}
-			},
-			"representation": {
-				"map": {}
-			}
-		},
-		"StructRepresentation_Tuple": {
-			"kind": "struct",
-			"fields": {
-				"fieldOrder": {
-					"type": {
-						"kind": "list",
-						"valueType": "FieldName"
-					},
-					"optional": true
-				}
-			},
-			"representation": {
-				"map": {}
-			}
-		},
-		"StructRepresentation_StringPairs": {
-			"kind": "struct",
-			"fields": {
-				"innerDelim": {
-					"type": "String"
-				},
-				"entryDelim": {
-					"type": "String"
-				}
-			},
-			"representation": {
-				"map": {}
-			}
-		},
-		"StructRepresentation_StringJoin": {
-			"kind": "struct",
-			"fields": {
-				"join": {
-					"type": "String"
-				},
-				"fieldOrder": {
-					"type": {
-						"kind": "list",
-						"valueType": "FieldName"
-					},
-					"optional": true
-				}
-			},
-			"representation": {
-				"map": {}
-			}
-		},
-		"StructRepresentation_ListPairs": {
-			"kind": "struct",
-			"fields": {},
-			"representation": {
-				"map": {}
-			}
-		},
-		"TypeEnum": {
-			"kind": "struct",
-			"fields": {
-				"members": {
-					"type": {
-						"kind": "list",
-						"valueType": "EnumMember"
+					"fields": {
+						"type": {
+							"map": {
+								"keyType": "FieldName",
+								"valueType": "StructRepresentation_Map_FieldDetails"
+							}
+						},
+						"optional": true
 					}
 				},
 				"representation": {
-					"type": "EnumRepresentation"
+					"map": {}
 				}
-			},
-			"representation": {
-				"map": {}
+			}
+		},
+		"StructRepresentation_Map_FieldDetails": {
+			"struct": {
+				"fields": {
+					"rename": {
+						"type": "String",
+						"optional": true
+					},
+					"implicit": {
+						"type": "AnyScalar",
+						"optional": true
+					}
+				},
+				"representation": {
+					"map": {}
+				}
+			}
+		},
+		"StructRepresentation_Tuple": {
+			"struct": {
+				"fields": {
+					"fieldOrder": {
+						"type": {
+							"list": {
+								"valueType": "FieldName"
+							}
+						},
+						"optional": true
+					}
+				},
+				"representation": {
+					"map": {}
+				}
+			}
+		},
+		"StructRepresentation_StringPairs": {
+			"struct": {
+				"fields": {
+					"innerDelim": {
+						"type": "String"
+					},
+					"entryDelim": {
+						"type": "String"
+					}
+				},
+				"representation": {
+					"map": {}
+				}
+			}
+		},
+		"StructRepresentation_StringJoin": {
+			"struct": {
+				"fields": {
+					"join": {
+						"type": "String"
+					},
+					"fieldOrder": {
+						"type": {
+							"list": {
+								"valueType": "FieldName"
+							}
+						},
+						"optional": true
+					}
+				},
+				"representation": {
+					"map": {}
+				}
+			}
+		},
+		"StructRepresentation_ListPairs": {
+			"struct": {
+				"fields": {},
+				"representation": {
+					"map": {}
+				}
+			}
+		},
+		"TypeEnum": {
+			"struct": {
+				"fields": {
+					"members": {
+						"type": {
+							"list": {
+								"valueType": "EnumMember"
+							}
+						}
+					},
+					"representation": {
+						"type": "EnumRepresentation"
+					}
+				},
+				"representation": {
+					"map": {}
+				}
 			}
 		},
 		"EnumMember": {
-			"kind": "string"
+			"string": {}
 		},
 		"EnumRepresentation": {
-			"kind": "union",
-			"members": [
-				"EnumRepresentation_String",
-				"EnumRepresentation_Int"
-			],
-			"representation": {
-				"keyed": {
-					"string": "EnumRepresentation_String",
-					"int": "EnumRepresentation_Int"
+			"union": {
+				"members": [
+					"EnumRepresentation_String",
+					"EnumRepresentation_Int"
+				],
+				"representation": {
+					"keyed": {
+						"string": "EnumRepresentation_String",
+						"int": "EnumRepresentation_Int"
+					}
 				}
 			}
 		},
 		"EnumRepresentation_String": {
-			"kind": "map",
-			"keyType": "EnumMember",
-			"valueType": "String"
+			"map": {
+				"keyType": "EnumMember",
+				"valueType": "String"
+			}
 		},
 		"EnumRepresentation_Int": {
-			"kind": "map",
-			"keyType": "EnumMember",
-			"valueType": "Int"
+			"map": {
+				"keyType": "EnumMember",
+				"valueType": "Int"
+			}
 		},
 		"TypeUnit": {
-			"kind": "struct",
-			"fields": {
+			"struct": {
+				"fields": {
+					"representation": {
+						"type": "UnitRepresentation"
+					}
+				},
 				"representation": {
-					"type": "UnitRepresentation"
+					"map": {}
 				}
-			},
-			"representation": {
-				"map": {}
 			}
 		},
 		"UnitRepresentation": {
-			"kind": "enum",
-			"members": [
-				"Null",
-				"True",
-				"False",
-				"Emptymap"
-			],
-			"representation": {
-				"string": {
-					"Null": "null",
-					"True": "true",
-					"False": "false",
-					"Emptymap": "emptymap"
+			"enum": {
+				"members": [
+					"Null",
+					"True",
+					"False",
+					"Emptymap"
+				],
+				"representation": {
+					"string": {
+						"Null": "null",
+						"True": "true",
+						"False": "false",
+						"Emptymap": "emptymap"
+					}
 				}
 			}
 		},
 		"TypeAny": {
-			"kind": "struct",
-			"fields": {},
-			"representation": {
-				"map": {}
+			"struct": {
+				"fields": {},
+				"representation": {
+					"map": {}
+				}
 			}
 		},
 		"TypeCopy": {
-			"kind": "struct",
-			"fields": {
-				"fromType": {
-					"type": "TypeName"
+			"struct": {
+				"fields": {
+					"fromType": {
+						"type": "TypeName"
+					}
+				},
+				"representation": {
+					"map": {}
 				}
-			},
-			"representation": {
-				"map": {}
 			}
 		}
 	}

--- a/specs/schemas/schema-schema.ipldsch.json
+++ b/specs/schemas/schema-schema.ipldsch.json
@@ -475,13 +475,16 @@
 			"fields": {
 				"prefixes": {
 					"kind": "map",
-					"keyType": "String",
+					"keyType": "HexString",
 					"valueType": "TypeName"
 				}
 			},
 			"representation": {
 				"map": {}
 			}
+		},
+		"HexString": {
+			"kind": "string"
 		},
 		"TypeStruct": {
 			"kind": "struct",

--- a/specs/schemas/schema-schema.ipldsch.json
+++ b/specs/schemas/schema-schema.ipldsch.json
@@ -44,6 +44,8 @@
 				"TypeUnion",
 				"TypeStruct",
 				"TypeEnum",
+				"TypeUnit",
+				"TypeAny",
 				"TypeCopy"
 			],
 			"representation": {
@@ -61,6 +63,8 @@
 						"union": "TypeUnion",
 						"struct": "TypeStruct",
 						"enum": "TypeEnum",
+						"unit": "TypeUnit",
+						"any": "TypeAny",
 						"copy": "TypeCopy"
 					}
 				}
@@ -79,7 +83,9 @@
 				"Link": null,
 				"Union": null,
 				"Struct": null,
-				"Enum": null
+				"Enum": null,
+				"Unit": null,
+				"Any": null
 			},
 			"representation": {
 				"string": {
@@ -93,7 +99,9 @@
 					"Link": "link",
 					"Union": "union",
 					"Struct": "struct",
-					"Enum": "enum"
+					"Enum": "enum",
+					"Unit": "unit",
+					"Any": "any"
 				}
 			}
 		},
@@ -685,6 +693,38 @@
 			"kind": "map",
 			"keyType": "EnumMember",
 			"valueType": "Int"
+		},
+		"TypeUnit": {
+			"kind": "struct",
+			"fields": {
+				"representation": {
+					"type": "UnitRepresentation"
+				}
+			},
+			"representation": {
+				"map": {}
+			}
+		},
+		"UnitRepresentation": {
+			"kind": "enum",
+			"members": {
+				"Null": null,
+				"True": null,
+				"False": null,
+				"Emptymap": null
+			},
+			"representation": {
+				"string": {
+					"Null": "null",
+					"True": "true",
+					"False": "false",
+					"Emptymap": "emptymap"
+				}
+			}
+		},
+		"TypeAny": {
+			"kind": "unit",
+			"representation": "emptymap"
 		},
 		"TypeCopy": {
 			"kind": "struct",

--- a/specs/schemas/schema-schema.ipldsch.json
+++ b/specs/schemas/schema-schema.ipldsch.json
@@ -68,7 +68,19 @@
 				"Enum": null
 			},
 			"representation": {
-				"string": {}
+				"string": {
+					"Bool": "bool",
+					"String": "string",
+					"Bytes": "bytes",
+					"Int": "int",
+					"Float": "float",
+					"Map": "map",
+					"List": "list",
+					"Link": "link",
+					"Union": "union",
+					"Struct": "struct",
+					"Enum": "enum"
+				}
 			}
 		},
 		"RepresentationKind": {
@@ -84,7 +96,16 @@
 				"Link": null
 			},
 			"representation": {
-				"string": {}
+				"string": {
+					"Bool": "bool",
+					"String": "string",
+					"Bytes": "bytes",
+					"Int": "int",
+					"Float": "float",
+					"Map": "map",
+					"List": "list",
+					"Link": "link"
+				}
 			}
 		},
 		"AnyScalar": {

--- a/specs/schemas/schema-schema.ipldsch.json
+++ b/specs/schemas/schema-schema.ipldsch.json
@@ -722,8 +722,11 @@
 			}
 		},
 		"TypeAny": {
-			"kind": "unit",
-			"representation": "emptymap"
+			"kind": "struct",
+			"fields": {},
+			"representation": {
+				"map": {}
+			}
 		},
 		"TypeCopy": {
 			"kind": "struct",

--- a/specs/schemas/schema-schema.ipldsch.json
+++ b/specs/schemas/schema-schema.ipldsch.json
@@ -622,7 +622,7 @@
 				"members": {
 					"type": {
 						"kind": "map",
-						"keyType": "EnumValue",
+						"keyType": "EnumMember",
 						"valueType": "Null"
 					}
 				},
@@ -634,7 +634,7 @@
 				"map": {}
 			}
 		},
-		"EnumValue": {
+		"EnumMember": {
 			"kind": "string"
 		},
 		"EnumRepresentation": {
@@ -652,12 +652,12 @@
 		},
 		"EnumRepresentation_String": {
 			"kind": "map",
-			"keyType": "EnumValue",
+			"keyType": "EnumMember",
 			"valueType": "String"
 		},
 		"EnumRepresentation_Int": {
 			"kind": "map",
-			"keyType": "EnumValue",
+			"keyType": "EnumMember",
 			"valueType": "Int"
 		},
 		"TypeCopy": {

--- a/specs/schemas/schema-schema.ipldsch.json
+++ b/specs/schemas/schema-schema.ipldsch.json
@@ -32,6 +32,20 @@
 		},
 		"Type": {
 			"kind": "union",
+			"members": [
+				"TypeBool",
+				"TypeString",
+				"TypeBytes",
+				"TypeInt",
+				"TypeFloat",
+				"TypeMap",
+				"TypeList",
+				"TypeLink",
+				"TypeUnion",
+				"TypeStruct",
+				"TypeEnum",
+				"TypeCopy"
+			],
 			"representation": {
 				"inline": {
 					"discriminantKey": "kind",
@@ -110,6 +124,13 @@
 		},
 		"AnyScalar": {
 			"kind": "union",
+			"members": [
+				"Bool",
+				"String",
+				"Bytes",
+				"Int",
+				"Float"
+			],
 			"representation": {
 				"kinded": {
 					"bool": "Bool",
@@ -154,6 +175,10 @@
 		},
 		"BytesRepresentation": {
 			"kind": "union",
+			"members": [
+				"BytesRepresentation_Bytes",
+				"AdvancedDataLayoutName"
+			],
 			"representation": {
 				"keyed": {
 					"bytes": "BytesRepresentation_Bytes",
@@ -210,6 +235,12 @@
 		},
 		"MapRepresentation": {
 			"kind": "union",
+			"members": [
+				"MapRepresentation_Map",
+				"MapRepresentation_StringPairs",
+				"MapRepresentation_ListPairs",
+				"AdvancedDataLayoutName"
+			],
 			"representation": {
 				"keyed": {
 					"map": "MapRepresentation_Map",
@@ -272,6 +303,10 @@
 		},
 		"ListRepresentation": {
 			"kind": "union",
+			"members": [
+				"ListRepresentation_List",
+				"AdvancedDataLayoutName"
+			],
 			"representation": {
 				"keyed": {
 					"list": "ListRepresentation_List",
@@ -306,6 +341,12 @@
 		"TypeUnion": {
 			"kind": "struct",
 			"fields": {
+				"members": {
+					"type": {
+						"kind": "list",
+						"valueType": "TypeName"
+					}
+				},
 				"representation": {
 					"type": "UnionRepresentation"
 				}
@@ -316,6 +357,14 @@
 		},
 		"UnionRepresentation": {
 			"kind": "union",
+			"members": [
+				"UnionRepresentation_Kinded",
+				"UnionRepresentation_Keyed",
+				"UnionRepresentation_Envelope",
+				"UnionRepresentation_Inline",
+				"UnionRepresentation_StringPrefix",
+				"UnionRepresentation_BytesPrefix"
+			],
 			"representation": {
 				"keyed": {
 					"kinded": "UnionRepresentation_Kinded",
@@ -435,6 +484,10 @@
 		},
 		"TypeTerm": {
 			"kind": "union",
+			"members": [
+				"TypeName",
+				"InlineDefn"
+			],
 			"representation": {
 				"kinded": {
 					"string": "TypeName",
@@ -444,6 +497,10 @@
 		},
 		"InlineDefn": {
 			"kind": "union",
+			"members": [
+				"TypeMap",
+				"TypeList"
+			],
 			"representation": {
 				"inline": {
 					"discriminantKey": "kind",
@@ -456,6 +513,13 @@
 		},
 		"StructRepresentation": {
 			"kind": "union",
+			"members": [
+				"StructRepresentation_Map",
+				"StructRepresentation_Tuple",
+				"StructRepresentation_StringPairs",
+				"StructRepresentation_StringJoin",
+				"StructRepresentation_ListPairs"
+			],
 			"representation": {
 				"keyed": {
 					"map": "StructRepresentation_Map",
@@ -575,6 +639,10 @@
 		},
 		"EnumRepresentation": {
 			"kind": "union",
+			"members": [
+				"EnumRepresentation_String",
+				"EnumRepresentation_Int"
+			],
 			"representation": {
 				"keyed": {
 					"string": "EnumRepresentation_String",

--- a/specs/schemas/schema-schema.ipldsch.json
+++ b/specs/schemas/schema-schema.ipldsch.json
@@ -485,9 +485,11 @@
 			"struct": {
 				"fields": {
 					"prefixes": {
-						"map": {
-							"keyType": "String",
-							"valueType": "TypeName"
+						"type": {
+							"map": {
+								"keyType": "String",
+								"valueType": "TypeName"
+							}
 						}
 					}
 				},
@@ -500,9 +502,11 @@
 			"struct": {
 				"fields": {
 					"prefixes": {
-						"map": {
-							"keyType": "HexString",
-							"valueType": "TypeName"
+						"type": {
+							"map": {
+								"keyType": "HexString",
+								"valueType": "TypeName"
+							}
 						}
 					}
 				},

--- a/specs/schemas/schema-schema.ipldsch.json
+++ b/specs/schemas/schema-schema.ipldsch.json
@@ -344,7 +344,7 @@
 				"members": {
 					"type": {
 						"kind": "list",
-						"valueType": "TypeName"
+						"valueType": "UnionMember"
 					}
 				},
 				"representation": {
@@ -353,6 +353,30 @@
 			},
 			"representation": {
 				"map": {}
+			}
+		},
+		"UnionMember": {
+			"kind": "union",
+			"members": [
+				"TypeName",
+				"UnionMemberInlineDefn"
+			],
+			"representation": {
+				"kinded": {
+					"string": "TypeName",
+					"map": "UnionMemberInlineDefn"
+				}
+			}
+		},
+		"UnionMemberInlineDefn": {
+			"kind": "union",
+			"members": [
+				"TypeLink"
+			],
+			"representation": {
+				"keyed": {
+					"link": "TypeLink"
+				}
 			}
 		},
 		"UnionRepresentation": {
@@ -379,12 +403,12 @@
 		"UnionRepresentation_Kinded": {
 			"kind": "map",
 			"keyType": "RepresentationKind",
-			"valueType": "TypeName"
+			"valueType": "UnionMember"
 		},
 		"UnionRepresentation_Keyed": {
 			"kind": "map",
 			"keyType": "String",
-			"valueType": "TypeName"
+			"valueType": "UnionMember"
 		},
 		"UnionRepresentation_Envelope": {
 			"kind": "struct",
@@ -399,7 +423,7 @@
 					"type": {
 						"kind": "map",
 						"keyType": "String",
-						"valueType": "TypeName"
+						"valueType": "UnionMember"
 					}
 				}
 			},
@@ -499,14 +523,16 @@
 			"kind": "union",
 			"members": [
 				"TypeMap",
-				"TypeList"
+				"TypeList",
+				"TypeLink"
 			],
 			"representation": {
 				"inline": {
 					"discriminantKey": "kind",
 					"discriminantTable": {
 						"map": "TypeMap",
-						"list": "TypeList"
+						"list": "TypeList",
+						"link": "TypeLink"
 					}
 				}
 			}

--- a/specs/schemas/schema-schema.ipldsch.json
+++ b/specs/schemas/schema-schema.ipldsch.json
@@ -242,7 +242,8 @@
 						"type": "Bool"
 					},
 					"representation": {
-						"type": "MapRepresentation"
+						"type": "MapRepresentation",
+						"optional": true
 					}
 				},
 				"representation": {
@@ -259,26 +260,16 @@
 		"MapRepresentation": {
 			"union": {
 				"members": [
-					"MapRepresentation_Map",
 					"MapRepresentation_StringPairs",
 					"MapRepresentation_ListPairs",
 					"AdvancedDataLayoutName"
 				],
 				"representation": {
 					"keyed": {
-						"map": "MapRepresentation_Map",
 						"stringpairs": "MapRepresentation_StringPairs",
 						"listpairs": "MapRepresentation_ListPairs",
 						"advanced": "AdvancedDataLayoutName"
 					}
-				}
-			}
-		},
-		"MapRepresentation_Map": {
-			"struct": {
-				"fields": {},
-				"representation": {
-					"map": {}
 				}
 			}
 		},
@@ -315,7 +306,8 @@
 						"type": "Bool"
 					},
 					"representation": {
-						"type": "ListRepresentation"
+						"type": "ListRepresentation",
+						"optional": true
 					}
 				},
 				"representation": {
@@ -332,12 +324,10 @@
 		"ListRepresentation": {
 			"union": {
 				"members": [
-					"ListRepresentation_List",
 					"AdvancedDataLayoutName"
 				],
 				"representation": {
 					"keyed": {
-						"list": "ListRepresentation_List",
 						"advanced": "AdvancedDataLayoutName"
 					}
 				}

--- a/specs/schemas/schema-schema.ipldsch.json
+++ b/specs/schemas/schema-schema.ipldsch.json
@@ -6,7 +6,7 @@
 		"SchemaMap": {
 			"map": {
 				"keyType": "TypeName",
-				"valueType": "Type"
+				"valueType": "TypeDefn"
 			}
 		},
 		"AdvancedDataLayoutName": {
@@ -33,42 +33,42 @@
 				}
 			}
 		},
-		"Type": {
+		"TypeDefn": {
 			"union": {
 				"members": [
-					"TypeBool",
-					"TypeString",
-					"TypeBytes",
-					"TypeInt",
-					"TypeFloat",
-					"TypeMap",
-					"TypeList",
-					"TypeLink",
-					"TypeUnion",
-					"TypeStruct",
-					"TypeEnum",
-					"TypeUnit",
-					"TypeAny",
-					"TypeCopy"
+					"TypeDefnBool",
+					"TypeDefnString",
+					"TypeDefnBytes",
+					"TypeDefnInt",
+					"TypeDefnFloat",
+					"TypeDefnMap",
+					"TypeDefnList",
+					"TypeDefnLink",
+					"TypeDefnUnion",
+					"TypeDefnStruct",
+					"TypeDefnEnum",
+					"TypeDefnUnit",
+					"TypeDefnAny",
+					"TypeDefnCopy"
 				],
 				"representation": {
 					"inline": {
 						"discriminantKey": "kind",
 						"discriminantTable": {
-							"bool": "TypeBool",
-							"string": "TypeString",
-							"bytes": "TypeBytes",
-							"int": "TypeInt",
-							"float": "TypeFloat",
-							"map": "TypeMap",
-							"list": "TypeList",
-							"link": "TypeLink",
-							"union": "TypeUnion",
-							"struct": "TypeStruct",
-							"enum": "TypeEnum",
-							"unit": "TypeUnit",
-							"any": "TypeAny",
-							"copy": "TypeCopy"
+							"bool": "TypeDefnBool",
+							"string": "TypeDefnString",
+							"bytes": "TypeDefnBytes",
+							"int": "TypeDefnInt",
+							"float": "TypeDefnFloat",
+							"map": "TypeDefnMap",
+							"list": "TypeDefnList",
+							"link": "TypeDefnLink",
+							"union": "TypeDefnUnion",
+							"struct": "TypeDefnStruct",
+							"enum": "TypeDefnEnum",
+							"unit": "TypeDefnUnit",
+							"any": "TypeDefnAny",
+							"copy": "TypeDefnCopy"
 						}
 					}
 				}
@@ -164,7 +164,7 @@
 				}
 			}
 		},
-		"TypeBool": {
+		"TypeDefnBool": {
 			"struct": {
 				"fields": {},
 				"representation": {
@@ -172,7 +172,7 @@
 				}
 			}
 		},
-		"TypeString": {
+		"TypeDefnString": {
 			"struct": {
 				"fields": {},
 				"representation": {
@@ -180,7 +180,7 @@
 				}
 			}
 		},
-		"TypeBytes": {
+		"TypeDefnBytes": {
 			"struct": {
 				"fields": {
 					"representation": {
@@ -214,7 +214,7 @@
 				}
 			}
 		},
-		"TypeInt": {
+		"TypeDefnInt": {
 			"struct": {
 				"fields": {},
 				"representation": {
@@ -222,7 +222,7 @@
 				}
 			}
 		},
-		"TypeFloat": {
+		"TypeDefnFloat": {
 			"struct": {
 				"fields": {},
 				"representation": {
@@ -230,7 +230,7 @@
 				}
 			}
 		},
-		"TypeMap": {
+		"TypeDefnMap": {
 			"struct": {
 				"fields": {
 					"keyType": {
@@ -306,7 +306,7 @@
 				}
 			}
 		},
-		"TypeList": {
+		"TypeDefnList": {
 			"struct": {
 				"fields": {
 					"valueType": {
@@ -352,7 +352,7 @@
 				}
 			}
 		},
-		"TypeLink": {
+		"TypeDefnLink": {
 			"struct": {
 				"fields": {
 					"expectedType": {
@@ -370,7 +370,7 @@
 				}
 			}
 		},
-		"TypeUnion": {
+		"TypeDefnUnion": {
 			"struct": {
 				"fields": {
 					"members": {
@@ -406,11 +406,11 @@
 		"UnionMemberInlineDefn": {
 			"union": {
 				"members": [
-					"TypeLink"
+					"TypeDefnLink"
 				],
 				"representation": {
 					"keyed": {
-						"link": "TypeLink"
+						"link": "TypeDefnLink"
 					}
 				}
 			}
@@ -525,7 +525,7 @@
 		"HexString": {
 			"string": {}
 		},
-		"TypeStruct": {
+		"TypeDefnStruct": {
 			"struct": {
 				"fields": {
 					"fields": {
@@ -592,17 +592,17 @@
 		"InlineDefn": {
 			"union": {
 				"members": [
-					"TypeMap",
-					"TypeList",
-					"TypeLink"
+					"TypeDefnMap",
+					"TypeDefnList",
+					"TypeDefnLink"
 				],
 				"representation": {
 					"inline": {
 						"discriminantKey": "kind",
 						"discriminantTable": {
-							"map": "TypeMap",
-							"list": "TypeList",
-							"link": "TypeLink"
+							"map": "TypeDefnMap",
+							"list": "TypeDefnList",
+							"link": "TypeDefnLink"
 						}
 					}
 				}
@@ -723,7 +723,7 @@
 				}
 			}
 		},
-		"TypeEnum": {
+		"TypeDefnEnum": {
 			"struct": {
 				"fields": {
 					"members": {
@@ -771,7 +771,7 @@
 				"valueType": "Int"
 			}
 		},
-		"TypeUnit": {
+		"TypeDefnUnit": {
 			"struct": {
 				"fields": {
 					"representation": {
@@ -801,7 +801,7 @@
 				}
 			}
 		},
-		"TypeAny": {
+		"TypeDefnAny": {
 			"struct": {
 				"fields": {},
 				"representation": {
@@ -809,7 +809,7 @@
 				}
 			}
 		},
-		"TypeCopy": {
+		"TypeDefnCopy": {
 			"struct": {
 				"fields": {
 					"fromType": {

--- a/specs/schemas/schema-schema.ipldsch.json
+++ b/specs/schemas/schema-schema.ipldsch.json
@@ -458,14 +458,30 @@
 			}
 		},
 		"UnionRepresentation_StringPrefix": {
-			"kind": "map",
-			"keyType": "String",
-			"valueType": "TypeName"
+			"kind": "struct",
+			"fields": {
+				"prefixes": {
+					"kind": "map",
+					"keyType": "String",
+					"valueType": "TypeName"
+				}
+			},
+			"representation": {
+				"map": {}
+			}
 		},
 		"UnionRepresentation_BytesPrefix": {
-			"kind": "map",
-			"keyType": "String",
-			"valueType": "TypeName"
+			"kind": "struct",
+			"fields": {
+				"prefixes": {
+					"kind": "map",
+					"keyType": "String",
+					"valueType": "TypeName"
+				}
+			},
+			"representation": {
+				"map": {}
+			}
 		},
 		"TypeStruct": {
 			"kind": "struct",


### PR DESCRIPTION
This is... a bulk fix to every inconsistency and bug in the schema-schema I've been able to find today.
On the sad side: hooo boy, is it a diff.
On the bright side: I... think should be every fix we'll need for a good while.  It fixes every bug and nit I've accumulated a note about in the last year or more.

The diff overall may be somewhat intimidating -- especially because in the JSON form, one of the changes causes an indentation level shift -- but if you go through it commit by commit, or focus attention on the DSL (which *didn't* have an indentation change) it should be much less terrifying.

The commit log is the best reference for what happened, but also, in brief, here was my checklist as I ripped through this:

- [x] bugfix: the `Type` declaration in json was missing its "members" field entirely, which was clearly invalid.
	- wait, WHAT?  We didn't actually define unions as having a members field?!???!?
	- so this is actually wrong _everywhere_.
	- okay fix all of it then, including the defn of 'TypeUnion' itself.
- [x] bugfix: the `EnumRepresentation` same
- [x] bugfix: the `TypeKind` enum is now all lowercase, instead of undesirably using TitleCase.
- [x] bugfix: the `RepresentationKind` enum is now all lowercase, instead of undesirably using TitleCase.
- [x] `EnumValue` is renamed to `EnumMember`, which says what it is better.
- [x] `TypeTerm` is renamed.  It's now `TypeNameOrInlineDefn`, which says what it is better.
- [x] fix the lack of ability to describe anonymous typed links in unions, and in other inline defns.
	- grabbed the diffs from https://github.com/ipld/ipld/pull/104 and ran away with them.
		- I solved this with a new type called `UnionMember`, plus `UnionMemberInlineDefn`.
		- n.b. some of the union representations use this new `UnionMember` type; some do not, because they can't actually contain values which would need it in order to be described.  (Inlines only work for members which are structs, and thus must be named; Stringprefix only works for strings, which must be named; etc.  There are additional details of validating those rules that is still pushed to the logical level, but there's no reason to let the schema describe things that are clearly  invalid, either.)
- [x] `unit` is now a typekind.
- [x] `unit` has representation strategies `null` `true` `false` and `emptymap`.
- [x] `any` is now a typekind.
	- amusingly, it's also defined using `unit`, of all things.  (Makes sense: there's nothing to describe about `any`, because that's how much of a wildcard it is.)
	  - [x] revisit.  It could equally well be describe using `struct {}`, as most other simple types do.  It might be hewing better to the "keep schema-schema using the minimal number of features" goal to define it this way.
	    - yep, done.  minimizing surface area is indeed desirable.
- [x] `any` doesn't have any representation strategies because the whole point is that it's a wildcard that basically allows any datamodel primitive and doesn't mess with them.
- [x] stringprefix: it should support a joiner?  Undecided, input wanted.
	- Our Go API had such an explicit joiner string, but we've mostly switched to thinking that was a misstep.  But it could also be fine to support, as long as it remains optional and an empty string is also accepted: I've realized you can get better error messages out of having a standard delimiter.  Not sure where this lies on cost/benefit.
	- May want to shift the whole thing to have a struct that contains an anonymous map just to make sure we can add that later as a smooth schema evolution if we want.
	- Decision: yes on the struct, so we have evolvability space reserved; no on actually putting a string field there at this time.
- [x] check on bytesprefix defn being correct, multibyte, etc, now.  (I think Rod might've already done this.  (Yes, confirmed, he did.  Thank you diligent sir.))
- [x] added `HexString` type as a marker for what's going on within bytesprefix.  (Not a functional change; mostly for clarity of communication.  It's still just a string kind, ultimately.)
- [x] the `Type` union is using keyed representation strategy, instead of inline.
	- Making an executive call here: we're going to keyed unions now. (Sorry @rvagg; I know you're still on the fense about this.  I'm pushing us over.  @mvdan also ran into this as a headscratcher because one of the trickiest things in this whole system to implement is inline unions.  I'm making it an explicit design rule for the schema-schema now: the schema-schema should intentionally use only as many of the features of schemas as necessary, and prefer the ones that we feel are reasonable to expect to be implemented early in a new IPLD library in a new language.  That means inline unions are _out_.)
	- this causes the majority of the diff, because it changes indentation
- [x] the `InlineDefn` and `UnionMemberInlineDefn` types are similarly switch to keyed strategy instead of inline.
- [x] Should we rename all these "kind" fields to "typekind"?  That would be in keeping with a resolution we made about increasing clarity in that terminology in this last year.
	- Nope; Irrelevant!  The switch to keyed unions nukes all of these instances of the string "kind" which were questionable.
- [x] Added description of prelude, and its declarations, to specs directory, in a new file.
	- Technically not causally relevant to most of the rest of this PR, but it's high time to just lay this out.  (And it shows where and why `any` typekind are important!)
- [x] `TypeEnum.members` is a map trying to act like a set.  We just introduced `TypeUnion.members` as a list.  Should we fix TypeEnum to use a list too, to be consistent?  ~Probably.~  Yes.
- [x] Consider: renaming `Type` to `TypeDefn`, which would say what it is better.
  - yes, gonna do this.
  - also, rename all `Type{typekind}` to `TypeDefn{typekind}` (and also `TypeCopy`, that odd duckling, to `TypeDefnCopy`).
  - Justification will be included in the commit message.
- [x] the `SchemaMap` type can be discarded; an anonymous map in the `Schema` struct is sufficient.  (Otherwise: I would've at least felt compelled to rename it `TypeDefnMap`.)
- [x] bugfix: `TypeLink.expectedType` is `TypeName` not `String`.
- [x] a heap of misc docs improvements.
- [x] default representation for maps and lists is communicated by absent 'representation' field.  (Is a schema-schema fix; we'd been doing it this way already.  Whoopsie.)

As I post this, I have a few unchecked checkboxes above.  All of those are things I think I still want to get done before landing this.  

I'd also like to land it... promptly.  A driver for tackling this work today is @mvdan's work on mechanical parsing of schema DMT data in our go libraries, and I want to get this all to solid ground so he can do that work once, rather than once and then immediately have to patch a bunch of it.  (Well, as much as possible.  I may actually be too late for that.  Still!  The iron is relatively hot!  At the very least it's not quenched yet!  Striking!)
