### PR TITLE
Signal ADLs in selectors

### DIFF
--- a/specs/selectors/index.md
+++ b/specs/selectors/index.md
@@ -183,13 +183,12 @@ type ExploreConditional struct {
 }
 
 ## ExploreInterpretAs is a transformation that attempts to 'reify' the current node
-## using an ADL specified by 'as'. Well-known ADLs are identified by their multicodec
-## identifier, and can be found under the tag 'ipld-adl' at
-## https://github.com/multiformats/multicodec/.
+## using an ADL specified by 'as'. ADLs are recognized by agreed-upon strings,
+## similar to libp2p protocols.
 ## The ExploreInterpretAs reification process may introduce a data-dependant amount
 ## of budget on evaluation based on the specific traversal and ADL implementation.
 type ExploreInterpretAs struct {
-	as int (rename "c")
+	as String (rename "c")
 	next Selector (rename ">")
 }
 

--- a/specs/selectors/index.md
+++ b/specs/selectors/index.md
@@ -65,6 +65,7 @@ type Selector union {
 	| ExploreUnion "|"
 	| ExploreConditional "&"
 	| ExploreRecursiveEdge "@" # sentinel value; only valid in some positions.
+	| ExploreInterpretAs "~"
 } representation keyed
 
 ## ExploreAll is similar to a `*` -- it traverses all elements of an array,
@@ -178,6 +179,17 @@ type ExploreUnion [Selector]
 ## but returns a match for the node it's on rather any of the deeper values.
 type ExploreConditional struct {
 	condition Condition (rename "&")
+	next Selector (rename ">")
+}
+
+## ExploreInterpretAs is a transformation that attempts to 'reify' the current node
+## using an ADL specified by 'as'. Well-known ADLs are identified by their multicodec
+## identifier, and can be found under the tag 'ipld-adl' at
+## https://github.com/multiformats/multicodec/.
+## The ExploreInterpretAs reification process may introduce a data-dependant amount
+## of budget on evaluation based on the specific traversal and ADL implementation.
+type ExploreInterpretAs struct {
+	as int (rename "c")
 	next Selector (rename ">")
 }
 


### PR DESCRIPTION
Introduce an `ExploreInterpretAs` wrapper in selectors to allow points in a traversal where the current `Node` should be `Reified` using identified, well-known ADLs.

Example:
```
{
	"~": {
               "c": "unixfs",
               ">": { ".": {} }
        }
}
```