### PR TITLE
improving the ADL signalling page

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -67,3 +67,16 @@ Enums are a scalar with countable cardinality.
 Unions are also known as "sum types" in some literature.
 We latched onto the term "union" because A) it's one word; and B) due to the popularization of that term for it in Facebook's GraphQL.
 Another common term for this concept is "variant".
+
+
+ADL-related
+-----------
+
+### Why couldn't you just bake in ADL signalling to the serial data in one clear way?
+
+Two major reasons:
+
+- We want to allow the same data to be viewed using various ADLs!  This is a critical feature -- and if the signalling mechanism is always embedded in the data itself, it makes this harder, not easier.
+- We don't want the IPLD Data Model to end up with "reserved words" -- and reserved words would be a requirement if we were baking ADL signalling into the serial data.  We won't go there; that would effectively break IPLD's promises for supporting arbitrary data.
+
+This means we end up with [many options for ADL signalling](/docs/advanced-data-layouts/signalling/).

--- a/docs/advanced-data-layouts/dynamic-loading.md
+++ b/docs/advanced-data-layouts/dynamic-loading.md
@@ -2,7 +2,7 @@
 title: ADL Dynamic Loading
 navTitle: Dynamic Loading
 eleventyNavigation:
-  order: 40
+  order: 50
   synopsys: Given that ADLs are a form of plugin, and contain code, how do we load them?  This page discusses options.
 ---
 

--- a/docs/advanced-data-layouts/identifying.md
+++ b/docs/advanced-data-layouts/identifying.md
@@ -1,0 +1,9 @@
+---
+title: Identifying ADLs
+eleventyNavigation:
+  order: 40
+  synopsys: How are ADLs referred to and identified?
+---
+
+Identifying ADLs
+================

--- a/docs/advanced-data-layouts/identifying.md
+++ b/docs/advanced-data-layouts/identifying.md
@@ -1,9 +1,0 @@
----
-title: Identifying ADLs
-eleventyNavigation:
-  order: 40
-  synopsys: How are ADLs referred to and identified?
----
-
-Identifying ADLs
-================

--- a/docs/advanced-data-layouts/index.md
+++ b/docs/advanced-data-layouts/index.md
@@ -7,16 +7,14 @@ eleventyNavigation:
 Advanced Data Layouts
 =====================
 
-Advanced Data Layouts ("ADLs") are an IPLD convention for customizing how to see and interact with some data.
+Advanced Data Layouts ("ADLs") are a way to take data in IPLD and customize additional ways to see and interact it.
 ADLs can be thought of like a "lens" for data: they can take some data and make it legible in a different way.
 
-ADLs are typically implemented as some kind of plugin system in IPLD libraries.
+The result of processing data with an ADL is still a [Data Model](/docs/data-model/) [Node](/docs/data-model/node/),
+which means other IPLD systems (like [pathing](/docs/data-model/pathing/) and [traversals](/docs/data-model/traversal/) and [Selectors](/specs/selectors/)) work transparently over ADLs.
 
 One of the most common uses of ADLs is sharded datastructures.
-However, other uses are possible.
-(For example, IPFS uses ADLs to make UnixFS's user-facing pathing work.
-Some people have researched using ADLs as part of encryption system design.
-More examples will be discussed below!)
+However, ADLs are a fairly open-ended plugin system; other uses are also possible.
 
 There's a lot to cover about ADLs, so we've split most of the content up into pages:
 
@@ -26,4 +24,3 @@ There's a lot to cover about ADLs, so we've split most of the content up into pa
 There are also pages in the specs chapters about ADLs: see [specs/advanced-data-layouts](/specs/advanced-data-layouts/).
 Those pages talk mostly about common and popular ADLs that are well known, providing specifications (and including fixture data);
 whereas the docs you'll find in these pages here are about the general concept, and how to implement your own.
-

--- a/docs/advanced-data-layouts/intro.md
+++ b/docs/advanced-data-layouts/intro.md
@@ -8,30 +8,68 @@ eleventyNavigation:
 Intro to Advanced Data Layouts
 ==============================
 
-Advanced Data Layouts ("ADLs") are an IPLD convention for customizing how to see and interact with some data.
+Advanced Data Layouts ("ADLs") are how IPLD supports handling large data -- such as creating maps with millions of entries -- are often used for creating "indexes"; and can be customized to other usecases as well.
+In general, ADLs are a way to customize how to see and interact with some data.
+They can be thought of like a "lens" for data: they can take some data and make it legible in a different way.
+ADLs usually appear as some kind of a plugin mechanism in IPLD libraries.
 
-A slightly more technical definition is:
-an ADL is some code which is applied to some [Data Model](/docs/data-model/) data
-in order to make it look like another [Node](/docs/data-model/node/);
-or when writing, an ADL presents a single [NodeBuilder](/design/libraries/nodes-and-kinds/#nodes-vs-nodebuilders)
-which transforms any input into other [Nodes](/docs/data-model/node/)
-(or possibly even several Nodes, perhaps even across several [blocks](/glossary/#block) when serialized!).
+### Technical Definition
+
+To give a slightly more technical definition, an ADL is:
+- some code which is applied to some [Data Model](/docs/data-model/) data
+  (can be one [Node](/docs/data-model/node/), or multiple, perhaps even spanning several blocks)...
+- in order to make it look like another [Node](/docs/data-model/node/);
+
+Or when writing:
+- an ADL presents a single [NodeBuilder](/design/libraries/nodes-and-kinds/#nodes-vs-nodebuilders)...
+- which transforms any input into one or more other [Nodes](/docs/data-model/node/)
+  (perhaps even across several [blocks](/glossary/#block) when serialized).
+
+We say that an ADL has a "synthesized" view -- which is the single Node, seen with the ADL --
+and a "substrate" -- which is the data as it is serialized.
+
+### Common Usecases
 
 One of the most common uses of ADLs is sharded datastructures.
-However, other uses are possible.
-(For example, IPFS uses ADLs to make UnixFS's user-facing pathing work.
-Some people have researched using ADLs as part of encryption system design.
-More examples will be discussed below!)
+These allow creating very large maps or lists.
 
-There are some forms of loose standardization for ADLs that are commonly used.
+Large bytes values can be created via ADLs, while stored sharded.
+This can be useful for representing "files" in IPLD
+(while still having the data chunked up into [blocks](/glossary/#block),
+which makes it easier to transfer the data in pieces).
+
+Other uses are also possible!  For example:
+- Sharding and big data, as discussed above;
+- "Indexes" can be constructed over data by using a map ADL (or more than one of them).
+- Whole application level behaviors can sometimes be useful to represent in ADLs!
+  For example, IPFS uses ADLs to make UnixFS: the user-facing filesystem-like pathing of UnixFS can be cleanly encapsulated as ADLs.
+- There is discussion of using ADLs as part of encryption systems.
+
+### Plugability
+
+ADLs usually resemble a "plugin" system.
+There are many different ADLs.
+Anyone can develop their own new ADL.
+
+To maximize interoperability, and save development time for common needs,
+we attempt to standardize the serial form for some ADLs that are commonly used.
 It's worth looking for existing ADLs that do what you need before rolling your own!
 (For example: If you're looking for a sharded, scalable map -- you're not the first!
 That's just one example of code you'll find you can share with others.)
 
+### Optional
+
+Note that data is always still data you can operate on *without* the ADL that wrote it, too:
+it's just going to look _different_.
+You can do things like transfer data, and even walk over the data, without an ADL,
+because it's still all IPLD [Data Model](/docs/data-model/).
+
+### More Information
+
 Learn briefly about where ADLs fit and what problems they solve in these sections:
 
-- [Quick Examples](#quick-examples)
 - [Where are ADLs in the big picture?](#where-are-adls-in-the-big-picture)
+  - [Codecs vs ADLs](#codecs-vs-adls)
   - [Schemas vs ADLs](#schemas-vs-adls)
 - [Applications of ADLs](#applications-of-adls)
 
@@ -39,15 +77,6 @@ Then, learn more about the details of what ADLs are and the boundaries of their 
 
 - [How ADLs Work](#how-adls-work)
 
-
-Quick Examples
---------------
-
-- Maps with sharded storage are often implemented using ADLs.  (The HAMT algorithm is popular, for example.)
-- Lists with sharded storage can be implemented as ADLs, too.
-- Large bytes sequences can be stored in sharded forms with ADLs.  (Imagine: using this to store large files, while splitting them into chunks, to make it easier to transport the large file in small parts.)
-- Application-level logic can sometimes be usefully represented in ADLs.  (For example, pathing over a "filesystem"-like datastructure, one may want both use a sharded map for large directories, and also stride over metadata objects without remark, and this could be wrapped up into a single ADL that provides pathing directly to file contents.)
-- There is research into using ADLs for purposes like encryption.
 
 
 Where are ADLs in the big picture?
@@ -58,7 +87,8 @@ Read the docs about the [Data Model](/docs/data-model/) first, if you haven't al
 ADLs build upon the concepts that are introduced and standardized by the Data Model.
 :::
 
-ADLs appear at a middle level of most stacks, if they're present.
+ADLs appear at a middle level of the stack.
+(You're definitely going to encounter codecs and the Data Model first.)
 
 ADLs are also entirely optional parts of IPLD: they're useful,
 but they're not the first thing you need to implement if building a new IPLD library in a new language.
@@ -75,6 +105,30 @@ but they're not the first thing you need to implement if building a new IPLD lib
 - [Traversals](/docs/data-model/traversal/) and [pathing](/docs/data-model/pathing/) work transparently over ADLs (which is part of why ADLs exist and what makes them awesome in the first place)!
 
 
+### Codecs vs ADLs
+
+Codecs take binary, illegible data, and turn it into [IPLD Data Model](/docs/data-model/).
+By contrast, ADLs take already-legible data -- e.g., data that's already been parsed by a codec --
+and make it legible in a different way.
+
+ADLs implicitly used a codec already (although ADLs are not tied to *a* codec;
+they just need to have *some* codec which handles serialization).
+Codecs do not use ADLs.
+
+In general, if you can accomplish some goal with an ADL instead of a codec,
+you probably should -- you'll be interoperable with more things as a result.
+(See also the [Getting Things Done](/docs/synthesis/gtd/) document about this.)
+
+ADLs can deal with multi-block data.
+This means they're suitable for solving a larger class of problems than a codec is.
+
+Codecs tend to take considerably longer to develop than ADLs.
+Codecs require more standardization effort,
+and require agreeing on a multicodec indicator.
+ADLs can be somewhat more freely developed,
+because of their nature as an optional layer.
+
+
 ### Schemas vs ADLs
 
 Both Schemas and ADLs can be described as "lenses" for data, but they have different purposes and scopes.
@@ -86,20 +140,26 @@ As described above, neither Schemas nor ADLs depend on the other.
 Both are optional parts of IPLD.
 Both can be used together or independently.
 
+Schemas can be used to "signal" where to use ADLs in a large forest of data;
+see the [Signalling](../signalling/) page for more on that.
 
-Applications of ADLs
---------------------
 
-ADLs are generally used to make some complex system simpler, or more legible.
+What ADLs Enable
+----------------
+
+ADLs are generally used to make some complex system simpler, or more legible;
+and, to unlock the ability of other IPLD features to apply over that data.
 
 Because ADLs make complex data structures readable and writable as "just" a [Node](/docs/data-model/node/),
-it means all the features of IPLD that work over regular Nodes work over ADLs, too.
+it means all the features of IPLD that work over regular Nodes work over ADLs, too!
 
 For example:
 - [Traversals](/docs/data-model/traversal/) and [pathing](/docs/data-model/pathing/) work transparently over ADLs;
 - [Selectors](/glossary/#selectors) work transparently over ADLs;
-- "IPLD Patch" tools (still forthcoming) work transprently over ADLs;
+- "IPLD Patch" tools (still forthcoming) work transparently over ADLs;
 - any kind of custom library functions you've written that work over Nodes?  They'll "just work" with ADLs.
+
+<!-- TODO: there should be a short h3 paragraph about each of these bullets. -->
 
 This reusability makes a ton of features possible for building systems with ADLs,
 and makes it work with a minimum of development effort.
@@ -113,25 +173,35 @@ For many applications of Selectors -- especially, say, the user of Selectors
 to ask someone else on the internet to *send* you data that you don't already have --
 this would make Selectors all but useless.
 However, by running Selectors *over* an ADL, things work out nicely.
-
+(You can see this principle working out in how [Graphsync](/specs/transport/graphsync/)
+can fulfill transport of all the blocks necessary to traverse a UnixFS path --
+just send the path itself, together with the instruction to look at the data with a UnixFS ADL,
+and the protocol will figure the rest out for you.)
+<!-- TODO: really need a page to link to for more detail about UnixFSv1. -->
 
 
 How ADLs Work
 -------------
 
-### ADLs make nodes look like another node
+ADLs require:
 
-:::todo
-- emphasis on *one* node as the result: whether it be map or list or bytes or etc, *one*.
-- include concrete example of what kind of transformation you'd be better off doing with schema.
-:::
+- some _interfaces_ in the IPLD library;
+- some _code_, which is plugged in somehow;
+- and some _signal_ which tells the IPLD library where to apply that code and thus return you that interface.
 
-### ADL interior data is still Data Model
+### ADLs need an interface
 
-:::todo
-- clarify that without ADL code activated, the raw data can still be read and even traversed... just differently.
-- clarify that codecs and ADLs compose, there's a clear layering there.
-:::
+... but often that interface is quite minor.
+
+For example, in the [go-ipld-prime definition of ADL](https://pkg.go.dev/github.com/ipld/go-ipld-prime/adl#ADL),
+it's almost entirely simply the [Node](/docs/data-model/node/) interface --
+the same interface already used for regular Data Model data.
+
+There may also be some interfaces required for the creation of the ADL value.
+(Starting to treat already-loaded nodes as an ADL is often called "reifying".)
+
+The exact details of the interfaces will vary per [implementation library](/libraries/);
+you'll need to consult the documentation of your library for more information.
 
 ### ADLs use code
 
@@ -145,9 +215,36 @@ these will all vary per IPLD library and the language the IPLD library is in.
 However, we currently consider that a research problem:
 some notes can be found in [open-research/ADLs-we-can-autoexecute](/design/open-research/ADL-autoexecution/).)
 
-### How do I know when to use an ADL to read data?
+### ADLs need to be signalled
+
+Because ADLs are optional lenses that you can _choose_ (or not choose) to engage
+when processing data, it follows that an application needs to "signal"
+whether or not they want to use an ADL; where in the data they want to use it;
+and which ADL to actually use on that data.
 
 We call this "the signalling problem".
 
-It has it's own page: go to [ADL signalling](../signalling/) to learn more.
+This gets quite in depth and has many possible solutions,
+so we explore it in its own page: hop over to [ADL signalling](../signalling/) to learn more.
 
+
+Can ADLs be Composed?
+---------------------
+
+Yes!  ADLs can be nested (an ADL can use another ADL inside itself),
+and multiple ADLs can be used in sequence when [pathing](/docs/data-model/pathing/) (even without knowing about each other).
+
+For example: the UnixFS ADL is actually composed of several smaller ADLs:
+
+- there's an ADL for sharded bytes, which is used for files in UnixFSv1.
+- there's a HAMT implementation, which acts like a map, and is part of how directories are implemented.
+- because directories also contain some metadata, there's both a raw view
+  (which may be a sharded map, and points to the metadata structures as its leaves)...
+- ... and a synthesized view, which jumps from one directory straight to the next directory or file content
+  (e.g., what you expect from pathing as a high level user!).
+
+In this example, we see both sequential use of ADLs, and composition of ADLs.
+When a directory points at another directory or a file, that's sequential use of two or more ADLs
+(and sometimes different ADLs; the directory maps use one, and the file bytes use another).
+When the UnixFS pathing ADL is used, that one composes *over* the other directory ADLs,
+using them internally, and then decorating on more of its own logic as well.

--- a/docs/advanced-data-layouts/intro.md
+++ b/docs/advanced-data-layouts/intro.md
@@ -71,12 +71,21 @@ Learn briefly about where ADLs fit and what problems they solve in these section
 - [Where are ADLs in the big picture?](#where-are-adls-in-the-big-picture)
   - [Codecs vs ADLs](#codecs-vs-adls)
   - [Schemas vs ADLs](#schemas-vs-adls)
-- [Applications of ADLs](#applications-of-adls)
+- [What ADLs enable](#what-adls-enable)
 
 Then, learn more about the details of what ADLs are and the boundaries of their interface in these sections:
 
 - [How ADLs Work](#how-adls-work)
 
+Also, if you're wondering [if ADLs can be composed](#can-adls-be-composed): spoiler, yes :)
+
+Beyond that, more detailed information is available in the other pages of this chapter, namely:
+
+- on [Naming](../naming/)
+- on [Signalling](../signalling/)
+- on [Dynamic Loading](../dynamic-loading/)
+
+---
 
 
 Where are ADLs in the big picture?

--- a/docs/advanced-data-layouts/known/index.md
+++ b/docs/advanced-data-layouts/known/index.md
@@ -1,0 +1,16 @@
+---
+title: "Known ADLs"
+eleventyNavigation:
+  order: 70
+  synopsys: A brief overview of some ADLs that are commonly known, and that you might want to check out.
+---
+
+Known ADLs
+==========
+
+Some well-known ADLs are described more thoroughly in the specs chapters about ADLs:
+see [specs/advanced-data-layouts](/specs/advanced-data-layouts/).
+
+<!-- Future work: expand this page and/or add subpages which give a brief intro
+to each ADL and its "why", before launching people over to its specs.
+Similar to the pages about known codecs! -->

--- a/docs/advanced-data-layouts/naming.md
+++ b/docs/advanced-data-layouts/naming.md
@@ -1,0 +1,20 @@
+---
+title: ADL Naming
+eleventyNavigation:
+  order: 30
+  synopsys: How are ADLs referred to and identified?
+---
+
+ADL Naming
+==========
+
+:::todo
+- This page should cover how ADLs are identified.
+- tl;dr:
+  - strings are used.
+    - hopefully these are descriptive of the algorithm.
+	- (multicodecs or other numerical indicators are not used, because legibility matters more than compactness.)
+	- (CIDs are not used, because there's no single interpreter of a single canonical bytecode, etc -- would presume jumping straight to the dynamic loading problem, which is too many jumps at once.)
+  - this is currently convention-heavy and a young field; we do not yet maintain recommendations nor a table of well-known values.
+  - naming and signalling are separate problems with separate solutions.  (The solutions interact, but don't confuse the problems.)
+:::

--- a/docs/advanced-data-layouts/signalling.md
+++ b/docs/advanced-data-layouts/signalling.md
@@ -9,15 +9,172 @@ eleventyNavigation:
 Advanced Data Layout Signalling
 ===============================
 
-:::todo
-- This page needs to be substantially rewritten to get to the point better.
-:::
+[Advanced Data Layouts](..) are a feature of IPLD which gives us "lenses" to view data in another way.
+
+This page is about answering the question: "How do I know when to use an ADL to read data?"
 
 ### How do I know when to use an ADL to read data?
 
-We call this "the signalling problem".
+Trick question.  You don't.
 
-In short: you don't.
+Using an ADL to read data is **_always_ optional**.
+If you don't want to use an ADL to read data, it's still legible --
+just as the [plain data model](/docs/data-model/) content,
+as a [codec](/glossary#codec) already gave it to you.
+
+You can also use different ADLs to read the same data.
+It's like putting on a different pair of glasses -- maybe some do
+a better job of making the data legible than others!
+
+### That wasn't helpful!
+
+Okay, okay.  It was important to get that out of the way, though --
+remember, there's going to be more than one answer coming up,
+and several of them can be "correct" at the same time.
+
+We call the question about how to decide to use an ADL
+"the signalling problem".
+
+There is more than one solution, and we call those "signalling mechanisms".
+
+
+Signalling Mechanisms
+---------------------
+
+So, we've identified  "the signalling problem".  Now let's identify solutions!
+
+Some of these will be design patterns; some are concrete and standardized protocol solutions.
+
+In brief:
+
+- Signalling in Selectors: there is signalling for invoking ADLs at specific positions in Selector walks.
+- Signalling with Schemas: there will be signalling for invoking ADLs at recurring positions in Schemas.  (It's on the roadmap, waiting for engineer allocation.)  (This one is useful because it works on recursive structures!)
+- Acting directly in code: there will be choices made by people's code, regardless of any signalling mechanisms.  (This isn't really following any convention of signalling, but worth remember that it's a practical reality.)
+- Suites which imply Signalling: some programs and protocols will implicitly (or explicitly) have _suites_ of logic which may include ADLs (and maybe other special behaviors that don't fit a clean plugin system) which are signalled by some protocol-specific mechanism.
+	- (n.b., this is defacto how a lot of IPFS works!  All of unixfsv1 can be seen as such a "suite".)
+- Signalling with "fat pointers": there might be information that is in-band to the serialized data which should signal where to use ADLs.
+	- (Note that this is a *bad idea* if not combined with a "suite" or other form of larger wrapped-around signalling -- be careful not to do [in-band signalling](https://en.wikipedia.org/wiki/In-band_signaling), which generally leads to security issues or other design problems.)
+	- (There have also been calls to make a standardized version of this and embed it in CIDs, creating a "CIDv2".)
+
+Let's discuss each of these in a short section.
+(As a rule of thumb, when you're designing a protocol -- you should probably be able to link to
+one of these sections and say "this: this is what this protocol is doing"!)
+
+### Code directly, without signalling
+
+:::todo
+- discuss this
+- link to the go-ipld-prime NodeReifier callback as an example of this
+:::
+
+
+### Signalling within Selectors
+
+
+
+:::todo
+- link to in-flight PRs
+:::
+
+
+### Signalling with Schemas
+
+IPLD Schemas allow you to name "types" in data, and also allow you to declare
+that you expect some data to processed by an ADL.
+
+For example, the Schema DSL for this looks something like the following:
+
+```ipldsch
+advanced ShardMap { ADL "HAMT/v1" }
+type Foobar map {String:String} using ShardMap
+```
+
+This is a very useful mechanism because it works recursively!
+
+For example, imagine you're specifying a filesystem-like protocol,
+and you want directories to use an ADL for sharding.
+You can simply declare that your directory type uses an ADL,
+say what it is, and say it acts like a map -- done!
+This will automatically work for all directories, no matter how deeply they may be nested.
+Declaring this is as simple as:
+
+```ipldsch
+type Dir union {
+	| Data "leaf"
+	| DirMap "dir"
+}
+type Data Bytes
+advanced ShardMap { ADL "HAMT/v1" }
+type DirMap map {String:Dir} using ShardMap
+```
+
+The Schema chapters of the documentation include a whole page on
+[Indicating ADLs with Schemas](/docs/schemas/features/indicating-adls/) which talks more about this.
+
+
+### Signal suites
+
+A signal "suite" is differentiated from the other approaches to signalling in that it's been reduced down to **one value**.
+
+Signal suites can be implemented in several ways:
+
+- Some applications may handle the signal value simply by [code directly](#code-directly-without-signalling).
+- Some applications and protocols may treat the signal value as a **shorthand**, and simply hand that off to other standard mechanisms like [schemas](#signalling-with-schemas).
+
+Signal suites are a very common choice, because it's the one with the least cognitive overhead for application developers, and requires the least up-front planning.
+It's easy to leave a cutout field in a protocol and declare it's for future-proofing by supporting a signal suite value, and _that works_.
+
+Signal suites aren't very standardized, though.
+Applications and protocols generally introduce their own specific enum values to name their well-known signal suites.
+Thereafter, it also becomes unavoidable for the application or protocol author to need to "gatekeep" the list of signal suites identifiers that are well-known in their system.
+If you're building a protocol that hosts other protocols, or an application that hosts user-defined data,
+you should prefer using some other more standardized and user-extensible signalling system such as [signalling with schemas](#signalling-with-schemas).
+
+
+### Signalling in-band
+
+TODO
+
+- by having wrapper structs (or other format of your choice -- this is roughly the same as the list of options you get with unions in the schema system, honestly)
+- proposal of CIDv2 (roughly the same, just removes the question of what to call the fields in the wrapper struct, makes it less stringy, arguably shortens things (dubious))
+
+
+### Combining Signalling Mechanisms
+
+You can write systems and protocols which use more than one signalling mechanism.
+
+For example, it's no problem to have an API with parameters (or even defaults) that use some application-specific [suites](#signal-suites),
+and also offers a different set of parameters that can take a user-supplied [schema](#signalling-with-schemas).
+
+It's also no problem to define an API which takes its main signalling input from a [schema](#signalling-with-schemas),
+but then allows overriding it (or disabling it) in certain positions via more signals in a [selector](#signalling-within-selectors).
+
+Check your IPLD library implementations for what they can support.
+
+
+### Other declarative signalling
+
+We've already listed all of the declarative signalling mechanisms that are currently well-known.
+
+However, additional systems may be possible.
+Some kind of declarative and recursive system that works without Schemas could be interesting, for example.
+
+However, it's probably worth trying to use one of the systems that already exists.
+See if it solves your problems first.
+
+(If you still want to create something new afterwards, draft a proposal!)
+
+
+
+Can't you just bake this in?
+----------------------------
+
+Nope.  IPLD describes ADLs as a plugin system, but leaves the trigger conditions and the assembly to you, on purpose.
+
+Two reasons:
+
+1. The IPLD Data Model does not have "reserved words".
+2. It's *good* that ADLs
 
 Since the data composing the "raw", interior data of an ADL is just regular IPLD Data Model
 (it must be, after all, since it's produced by some [Codec](/docs/codecs/), which by definition produces data structures describable by the Data Model),
@@ -30,61 +187,3 @@ So!  Signalling must come from somewhere else.
 
 There are a variety of valid options, and we'll explore some of them,
 and examples of them, in the next sections.
-
-Signalling Mechanisms
----------------------
-
-- Signalling in Selectors: there is signalling for invoking ADLs at specific positions in Selector walks.
-- Signalling with Schemas: there will be signalling for invoking ADLs at recurring positions in Schemas.  (It's on the roadmap, waiting for engineer allocation.)  (This one is useful because it works on recursive structures!)
-- Acting directly in code: there will be choices made by people's code, regardless of any signalling mechanisms.  (This isn't really following any convention of signalling, but worth remember that it's a practical reality.)
-- Suites which imply Signalling: some programs and protocols will implicitly (or explicitly) have _suites_ of logic which may include ADLs (and maybe other special behaviors that don't fit a clean plugin system) which are signalled by some protocol-specific mechanism.
-	- (n.b., this is defacto how a lot of IPFS works!  All of unixfsv1 can be seen as such a "suite".)
-- Signalling with "fat pointers": there might be information that is in-band to the serialized data which should signal where to use ADLs.
-	- (Note that this is a *bad idea* if not combined with a "suite" or other form of larger wrapped-around signalling -- be careful not to do [in-band signalling](https://en.wikipedia.org/wiki/In-band_signaling), which generally leads to security issues or other design problems.)
-	- (There have also been calls to make a standardized version of this and embed it in CIDs, creating a "CIDv2".)
-
-:::todo
-Some of the above bulletpoints have full sections below.  The others need sections too.
-:::
-
-#### Signalling with Schemas
-
-One useful system we have which can provide an answer to the signalling question are IPLD Schemas.
-Since Schemas are already a declarative way to talk about the structure of data,
-it's quite reasonable that they should also be able to talk about where the structure of data uses an ADL.
-
-A page on [Indicating ADLs with Schemas](/docs/schemas/features/indicating-adls/) talks more about this.
-
-However, you don't have to use IPLD Schemas if you want to use ADLs.
-Keep reading the next couple of sections for more alternatives that you can use to answer the signalling question.
-
-:::todo
-- a remark should be present here on the interesting limitation about *non*-recursive descriptions being somewhat high-friction to reach with this mechanism.
-  (although maybe this belongs in a separate deeper-diving doc in another page).
-:::
-
-#### Direct action within libraries
-
-:::todo
-- discuss this
-- link to the go-ipld-prime NodeReifier callback as an example of this
-:::
-
-#### Other declarative signalling
-
-We have no currently active specifications for other forms of declarative signalling.
-
-However, you can imagine making such a system yourself fairly easily:
-all that's necessary is to decide what that declarative format is that you want,
-and write a system that binds it to the relevant programmatic APIs of the IPLD libraries you use,
-and everything should work out from there.
-
-Additional declarative signalling specifications may be something that is ratified into IPLD in the future.
-(If you'd like to drive this work, please feel free to get in touch!)
-
-(Some systems have already done this in their own ways: for example,
-parts of the Filecoin Lotus project expose "paths" in their CLI which have an extension
-that is used in that application to signal where to engage ADLs.
-You can do things like this in your own applications, too!
-It's worth noting, however, that what the Filecoin Lotus project does here is not considered a well-specified IPLD behavior,
-and in fact contains several caveats which constrains what is valid data for that application to process to a range that is far narrower than what the IPLD Data Model specifies.)

--- a/docs/advanced-data-layouts/signalling.md
+++ b/docs/advanced-data-layouts/signalling.md
@@ -1,6 +1,6 @@
 ---
 title: ADL Signalling
-navTitle: Signalling
+navTitle: Signalling ADLs
 eleventyNavigation:
   order: 30
   synopsys: How are ADLs applied?  How does data signal that it should be interpreted with an ADL?
@@ -11,70 +11,90 @@ Advanced Data Layout Signalling
 
 [Advanced Data Layouts](..) are a feature of IPLD which gives us "lenses" to view data in another way.
 
-This page is about answering the question: "How do I know when to use an ADL to read data?"
+This page is about answering the question: "How do I tell IPLD when and where to apply an ADL while reading data?"
 
-### How do I know when to use an ADL to read data?
+:::info
+Read [the intro page about ADLs](../intro/) first, if you haven't already.
+The broader concept of ADLs, and why they need a concept of "signalling", is introduced there.
+:::
 
-Trick question.  You don't.
 
-Using an ADL to read data is **_always_ optional**.
+Always Optional
+---------------
+
+An important thing to remember about ADLs is that the use of them is _always optional_.
+
+Data can be read with an ADL -- or without.
+[Pathing](/docs/data-model/pathing/) over the data works differently depending on whether
+an ADL is engaged or not, but the data can _be_ pathed over, in some way, either way.
 If you don't want to use an ADL to read data, it's still legible --
 just as the [plain data model](/docs/data-model/) content,
 as a [codec](/glossary#codec) already gave it to you.
 
-You can also use different ADLs to read the same data.
+And different ADLs can be applied to the same data,
+resulting in different views!
 It's like putting on a different pair of glasses -- maybe some do
 a better job of making the data legible than others!
 
-### That wasn't helpful!
+Therefore, signalling mechanisms -- things that tell you, or tell an IPLD library,
+when to engage an ADL, and [what ADL to engage](../identifying/) --
+are *also* optional, and by nature, advisory.
 
-Okay, okay.  It was important to get that out of the way, though --
-remember, there's going to be more than one answer coming up,
-and several of them can be "correct" at the same time.
-
-We call the question about how to decide to use an ADL
-"the signalling problem".
-
-There is more than one solution, and we call those "signalling mechanisms".
+We'll talk about some of the various mechanisms a system can use in the next sections.
 
 
 Signalling Mechanisms
 ---------------------
 
-So, we've identified  "the signalling problem".  Now let's identify solutions!
-
-Some of these will be design patterns; some are concrete and standardized protocol solutions.
+There are many ways to approach solving the signalling problem.
 
 In brief:
 
-- Signalling in Selectors: there is signalling for invoking ADLs at specific positions in Selector walks.
-- Signalling with Schemas: there will be signalling for invoking ADLs at recurring positions in Schemas.  (It's on the roadmap, waiting for engineer allocation.)  (This one is useful because it works on recursive structures!)
-- Acting directly in code: there will be choices made by people's code, regardless of any signalling mechanisms.  (This isn't really following any convention of signalling, but worth remember that it's a practical reality.)
-- Suites which imply Signalling: some programs and protocols will implicitly (or explicitly) have _suites_ of logic which may include ADLs (and maybe other special behaviors that don't fit a clean plugin system) which are signalled by some protocol-specific mechanism.
-	- (n.b., this is defacto how a lot of IPFS works!  All of unixfsv1 can be seen as such a "suite".)
-- Signalling with "fat pointers": there might be information that is in-band to the serialized data which should signal where to use ADLs.
-	- (Note that this is a *bad idea* if not combined with a "suite" or other form of larger wrapped-around signalling -- be careful not to do [in-band signalling](https://en.wikipedia.org/wiki/In-band_signaling), which generally leads to security issues or other design problems.)
-	- (There have also been calls to make a standardized version of this and embed it in CIDs, creating a "CIDv2".)
+- [Code directly, without signalling](#code-directly-without-signalling)
+- [Signalling with Schemas](#signalling-with-schemas)
+- [Signalling with Selectors](#signalling-with-selectors)
+- [Signal suites](#signal-suites)
+- [Signalling in-band](#signalling-in-band)
+- or there may be [other, new declarative signalling systems](#other-declarative-signalling) as yet undeveloped.
+
+Some of these are concrete, standardized protocol solutions.
+Some are more like design patterns.
+(We'll always advise trying to use the more standardized solutions,
+but we can't stop systems in the wild from wiring things as they please,
+so we try to at least provide terminology for describing those less standardized approaches, too.)
+
+You can also [combine signalling mechanisms](#combining-signalling-mechanisms).
 
 Let's discuss each of these in a short section.
 (As a rule of thumb, when you're designing a protocol -- you should probably be able to link to
 one of these sections and say "this: this is what this protocol is doing"!)
 
+
 ### Code directly, without signalling
 
-:::todo
-- discuss this
-- link to the go-ipld-prime NodeReifier callback as an example of this
+The most direct way to engage with the signalling problem is to simply _do things_, using application code, and directly calling library functions.
+
+This approach is arguably not a signalling mechanism at all.
+When we talk about direct action in code, we mean there isn't really any convention at all in play;
+or if it is, it's "implementation defined" by the code you have written.
+However, even if it isn't "signalling", it's worth remembering that this it's a practical reality:
+applications can _always_ be written this way.
+This is just the most degenerate, least useful, least standardized way of signalling.
+
+:::tip
+We encourage using one of the other mechanisms of signalling when working the IPLD ecosystem,
+because the more declarative and standard of a signalling system you use,
+the easier it will make it for others to interact with your data,
+and the more that IPLD application and library developers can help you.
 :::
 
+Some IPLD libraries do provide feature hooks to help you do this.
+For example, in the golang implementation, a [NodeReifer callback](https://pkg.go.dev/github.com/ipld/go-ipld-prime/linking#NodeReifier) provides a place to hook custom code into the flow for loading data,
+which allows it to be used throughout other library behaviors like traversals.
 
-### Signalling within Selectors
-
-
-
-:::todo
-- link to in-flight PRs
-:::
+But again, this is probably pretty disappointing, if you were looking for standardization.
+So let's continue on to the next sections, which will describe other approaches
+for more declarative and more standardized mechanisms of signalling.
 
 
 ### Signalling with Schemas
@@ -89,7 +109,15 @@ advanced ShardMap { ADL "HAMT/v1" }
 type Foobar map {String:String} using ShardMap
 ```
 
-This is a very useful mechanism because it works recursively!
+In this example, the declaration `using ShardMap` says that the `Foobar` type will be using an ADL,
+and refers to an `advanced` clause elsewhere in the schema which must finish defining `ShardMap`.
+Then, where the `advanced` clause states the string `"HAMT/v1"`,
+that string is meant to [identify the ADL to use](../identifying/).
+(Note that the schema also still states that it expects that type to be a [`map` kind](/docs/schemas/features/typekinds/#map) --
+this is because ADLs "aren't special"; they're just presenting a plain datamodel kind to the schema layer when applied, and the schema layer still needs to turn that into a typekind.
+Or from another justification: a human reading the schema should still know what typekind to expect here even if they have no idea what the ADL implementation is.)
+
+Schema-based signalling is a very useful mechanism because it works recursively!
 
 For example, imagine you're specifying a filesystem-like protocol,
 and you want directories to use an ADL for sharding.
@@ -112,34 +140,66 @@ The Schema chapters of the documentation include a whole page on
 [Indicating ADLs with Schemas](/docs/schemas/features/indicating-adls/) which talks more about this.
 
 
+### Signalling with Selectors
+
+[Selectors](/glossary/#selectors) can contain clauses which indicate that an ADL is to be applied at certain positions during the walk that the Selector is guiding.
+
+See the `InterpretAs` clause in [the Selector spec](/specs/selectors/).
+It can be placed anywhere within a Selector expression to say "apply an ADL here, before continuing the traversal".
+The selector expressions which are children of that clause will then be evaluated on the synthesized ADL node.
+
+
 ### Signal suites
 
-A signal "suite" is differentiated from the other approaches to signalling in that it's been reduced down to **one value**.
+Suites which imply Signalling: some programs and protocols will implicitly (or explicitly) have _suites_ of logic which may include ADLs (and maybe other special behaviors that don't fit a clean plugin system) which are signalled by some protocol-specific mechanism.
+
+A signal "suite" is differentiated from the other approaches to signalling in that it's been reduced down to **one value** -- or possibly even zero values, and the application itself implies a single fixed suite -- and that choice is considered suffusive in that application or protocol.
 
 Signal suites can be implemented in several ways:
 
-- Some applications may handle the signal value simply by [code directly](#code-directly-without-signalling).
+- Some applications may handle the signal value by using [code directly](#code-directly-without-signalling).
 - Some applications and protocols may treat the signal value as a **shorthand**, and simply hand that off to other standard mechanisms like [schemas](#signalling-with-schemas).
 
 Signal suites are a very common choice, because it's the one with the least cognitive overhead for application developers, and requires the least up-front planning.
-It's easy to leave a cutout field in a protocol and declare it's for future-proofing by supporting a signal suite value, and _that works_.
+If one just "starts writing code" and does no special planning, one ends up with an implicit single "suite" for the whole application.
+If one does think about evolvability, but doesn't want to do anything user-configurable or extensible,
+then a single "suite" is a very minimal and easy incremental step:
+it's easy to add a single field to a protocol and declare it's for future-proofing by supporting a signal suite value, and start by hardcoding one value to that, and _that works_.
+(It's also neat to observe that one can implement the initial behavior as a "suite" backed by a [code directly](#code-directly-without-signalling) system,
+and then add a future "suite" which just hands off to use of one of the other more standardized and user-configurable signalling mechanisms!)
 
-Signal suites aren't very standardized, though.
-Applications and protocols generally introduce their own specific enum values to name their well-known signal suites.
-Thereafter, it also becomes unavoidable for the application or protocol author to need to "gatekeep" the list of signal suites identifiers that are well-known in their system.
+Signal suites aren't very standardized; by nature, they're usually "grown" (and sometimes become well-described only in retrospective).
+Applications and protocols generally end up with their own specific enum values to name their well-known signal suites, and with their own unique place to convey the suite signal.
+
+For an example of signal suites in the wild, consider IPFS.
+Many of the APIs, both in the CLI and the HTTP API of IPFS, implicitly work on UnixFS.
+Some of the APIs work on the raw IPLD Data Model, and don't consider UnixFS at all.
+Generally, in the CLI of IPFS, it's the command name itself that's doing the "signalling" here.
+In the HTTP API, similarly, a prefix of the URL path (or sometimes even a subdomain) may be doing "signalling" work and causing the UnixFS "suite" to be engaged.
+
+While they are easy to do, note that there are several downsides to bespoke signal suites:
+
+- First, it doesn't help you tap into other IPLD features.  For example, protocols like [Graphsync](/specs/transports/graphsync/) can only give you their maximum powers if you can communicate your ADL signalling in a standard way that Graphsync can understand.  Bespoke signal suites aren't that.
+- Second, if one is working on a project that wants to build an ecosystem and become user-extensible, bespokeness is not to your advantage.  By having a signal suite of your own defining, one inevitably ends up with the need to begin "gatekeeping" the list of signal suites identifiers that are well-known in their system.  This just is no fun.
+
 If you're building a protocol that hosts other protocols, or an application that hosts user-defined data,
-you should prefer using some other more standardized and user-extensible signalling system such as [signalling with schemas](#signalling-with-schemas).
+it may be preferable to consider using some other more standardized and user-extensible signalling system,
+such as [signalling with schemas](#signalling-with-schemas).
 
 
 ### Signalling in-band
 
-TODO
+Signalling in-band refers to a broad category of approaches:
+if the idea is based on some part of the raw data containing a special piece of data
+that says which ADL to use, we call that "in-band signalling".
 
-- by having wrapper structs (or other format of your choice -- this is roughly the same as the list of options you get with unions in the schema system, honestly)
-- proposal of CIDv2 (roughly the same, just removes the question of what to call the fields in the wrapper struct, makes it less stringy, arguably shortens things (dubious))
+We tend to recommend against in-band signalling, in broad strokes,
+because it runs contrary to the idea that ADLs should be like lenses,
+and that one should be able to use any ADL one wants to process some data,
+or use more than one, varying the choice by context.
 
 
-### Combining Signalling Mechanisms
+### Combining signalling mechanisms
 
 You can write systems and protocols which use more than one signalling mechanism.
 
@@ -156,34 +216,20 @@ Check your IPLD library implementations for what they can support.
 
 We've already listed all of the declarative signalling mechanisms that are currently well-known.
 
-However, additional systems may be possible.
-Some kind of declarative and recursive system that works without Schemas could be interesting, for example.
+However, additional systems are still possible -- just waiting for your invention and specification.
+Some kind of declarative and recursive system that works without Schemas and is also independent of Selectors could be interesting, for example.
+If you still want to try to specify such a system, draft a proposal!
 
-However, it's probably worth trying to use one of the systems that already exists.
-See if it solves your problems first.
-
-(If you still want to create something new afterwards, draft a proposal!)
-
+Today, however, it's probably worth trying to use one of the systems that already exists.
+See if one of our mechanisms detailed above can solve your problems today.
 
 
-Can't you just bake this in?
-----------------------------
+Signalling vs Picking an Algorithm
+----------------------------------
 
-Nope.  IPLD describes ADLs as a plugin system, but leaves the trigger conditions and the assembly to you, on purpose.
+Signalling that an ADL is to be used at all is half the battle.
+Thereafter, one an IPLD library also has to react to that signal by figuring out what
+ADL algorithm you wanted; getting some code that does it; and then actually applying.
 
-Two reasons:
-
-1. The IPLD Data Model does not have "reserved words".
-2. It's *good* that ADLs
-
-Since the data composing the "raw", interior data of an ADL is just regular IPLD Data Model
-(it must be, after all, since it's produced by some [Codec](/docs/codecs/), which by definition produces data structures describable by the Data Model),
-then it follows that there's absolutely no way for this data to unambiguously indicate that it needs an ADL in order to be understood.
-If there was, it would imply that there's some kind of "reserved words" in the Data Model,
-which would violate some of our other central goals in IPLD, because it would mean some perfectly normal maps and lists would be invalid IPLD or gain magical meaning that they shouldn't;
-we don't want any of that.
-
-So!  Signalling must come from somewhere else.
-
-There are a variety of valid options, and we'll explore some of them,
-and examples of them, in the next sections.
+These other steps are covered in the page on [Identifying ADLs](../identifying/),
+and [Dynamic Loading](../dynamic-loading/).

--- a/docs/advanced-data-layouts/signalling.md
+++ b/docs/advanced-data-layouts/signalling.md
@@ -2,7 +2,7 @@
 title: ADL Signalling
 navTitle: Signalling ADLs
 eleventyNavigation:
-  order: 30
+  order: 40
   synopsys: How are ADLs applied?  How does data signal that it should be interpreted with an ADL?
 ---
 
@@ -37,7 +37,7 @@ It's like putting on a different pair of glasses -- maybe some do
 a better job of making the data legible than others!
 
 Therefore, signalling mechanisms -- things that tell you, or tell an IPLD library,
-when to engage an ADL, and [what ADL to engage](../identifying/) --
+when to engage an ADL, and [what ADL to engage](../naming/) --
 are *also* optional, and by nature, advisory.
 
 We'll talk about some of the various mechanisms a system can use in the next sections.
@@ -112,7 +112,7 @@ type Foobar map {String:String} using ShardMap
 In this example, the declaration `using ShardMap` says that the `Foobar` type will be using an ADL,
 and refers to an `advanced` clause elsewhere in the schema which must finish defining `ShardMap`.
 Then, where the `advanced` clause states the string `"HAMT/v1"`,
-that string is meant to [identify the ADL to use](../identifying/).
+that string is meant to [identify the ADL to use](../naming/).
 (Note that the schema also still states that it expects that type to be a [`map` kind](/docs/schemas/features/typekinds/#map) --
 this is because ADLs "aren't special"; they're just presenting a plain datamodel kind to the schema layer when applied, and the schema layer still needs to turn that into a typekind.
 Or from another justification: a human reading the schema should still know what typekind to expect here even if they have no idea what the ADL implementation is.)
@@ -179,7 +179,7 @@ In the HTTP API, similarly, a prefix of the URL path (or sometimes even a subdom
 
 While they are easy to do, note that there are several downsides to bespoke signal suites:
 
-- First, it doesn't help you tap into other IPLD features.  For example, protocols like [Graphsync](/specs/transports/graphsync/) can only give you their maximum powers if you can communicate your ADL signalling in a standard way that Graphsync can understand.  Bespoke signal suites aren't that.
+- First, it doesn't help you tap into other IPLD features.  For example, protocols like [Graphsync](/specs/transport/graphsync/) can only give you their maximum powers if you can communicate your ADL signalling in a standard way that Graphsync can understand.  Bespoke signal suites aren't that.
 - Second, if one is working on a project that wants to build an ecosystem and become user-extensible, bespokeness is not to your advantage.  By having a signal suite of your own defining, one inevitably ends up with the need to begin "gatekeeping" the list of signal suites identifiers that are well-known in their system.  This just is no fun.
 
 If you're building a protocol that hosts other protocols, or an application that hosts user-defined data,
@@ -207,7 +207,7 @@ For example, it's no problem to have an API with parameters (or even defaults) t
 and also offers a different set of parameters that can take a user-supplied [schema](#signalling-with-schemas).
 
 It's also no problem to define an API which takes its main signalling input from a [schema](#signalling-with-schemas),
-but then allows overriding it (or disabling it) in certain positions via more signals in a [selector](#signalling-within-selectors).
+but then allows overriding it (or disabling it) in certain positions via more signals in a [selector](#signalling-with-selectors).
 
 Check your IPLD library implementations for what they can support.
 
@@ -231,5 +231,5 @@ Signalling that an ADL is to be used at all is half the battle.
 Thereafter, one an IPLD library also has to react to that signal by figuring out what
 ADL algorithm you wanted; getting some code that does it; and then actually applying.
 
-These other steps are covered in the page on [Identifying ADLs](../identifying/),
+These other steps are covered in the page on [Naming ADLs](../naming/),
 and [Dynamic Loading](../dynamic-loading/).


### PR DESCRIPTION
~(Still very much WIP.)~  Almost not WIP at all yet, but still a few blanks to fill in.

The page talking about different strategies for ADL signalling still needed some love.

This diff enumerates some more strategies, each under their own h3, and should introduce and compare them a bit better than before.

One of the key concepts is also that none of these is "the" strategy; hopefully that comes across more clearly by the time we're done here.