### PR TITLE
Introduce key for specifing node reification realization

### DIFF
--- a/specs/selectors/index.md
+++ b/specs/selectors/index.md
@@ -189,8 +189,22 @@ type ExploreConditional struct {
 ## of budget on evaluation based on the specific traversal and ADL implementation.
 type ExploreInterpretAs struct {
 	as String (rename "c")
+	realize InterpretRealize (rename "r") 
 	next Selector (rename ">")
 }
+
+## InterpretRealize is a union type that specifies the behavior for reification
+## of the interpreted node. When `root` is specified, the node will be reified,
+## and the resulting node will be pathed through as specified by the `next`
+## selector of the ExploreInterpretAs directive. In contrast, when `full` is
+## specified, the reified node will have it's concrete value enumerated based
+## on the resulting kind. If the node has a kind of List or Map, an iteration
+## of all items in the node will be performed, forcing realization and traversal
+## of the substrate nodes backing the reified ADL node.
+type InterpretRealize union {
+	| InterpretRealize_Root "root"
+	| InterpretRealize_Full "full"
+} representation keyed
 
 ## Matcher marks a node to be included in the "result" set.
 ## (All nodes traversed by a selector are in the "covered" set (which is a.k.a.


### PR DESCRIPTION
I think in retrospect we don't have any pressing need to introduce this additional behavior now.

This PR adds a mode to `InterpretAs` to distinguish between calling 'Reify' and actually getting the concrete value or enumeration out of the resulting node based upon it's kind.

There are cases where asking for the value of the node will be different than what can be done otherwise with a selector:
* Imagine a Bytes ADL structure that keeps reference to partial states that have been added and removed for use in a 'diff' style functionality. A 'recurse all' selector against such a reified node would touch more blocks than accessing the 'asBytes' of the node.

I had previously been thinking this was needed for a UnixFS directory, where I wanted to specify a selector to enumerate the files in the directory but didn't want to select the blocks of the files themselves. This is possible without this addition using a recursion with limit 1, since that will select the children of the individual directory entries, but will not traverse the links to the files themselves.