### PR TITLE
docs: dag-cbor: expand remarks on density and add remarks on complexity

### DIFF
--- a/docs/codecs/known/dag-cbor/index.md
+++ b/docs/codecs/known/dag-cbor/index.md
@@ -53,5 +53,35 @@ DAG-CBOR supports the **full** IPLD [Data Model](/glossary/#data-model), complet
 
 ### density
 
-DAG-CBOR's density is roughly comparable to JSON.  E.g. If a series of maps have the same keys repeated,
-then those keys will be repeated in the DAG-CBOR serial form.
+Theoretically, DAG-CBOR's density is roughly comparable to JSON,
+because they're structurally similar.
+E.g. If a series of maps have the same keys repeated,
+then those keys will be repeated in the DAG-CBOR serial form,
+just as they would be in a JSON encoding.
+
+In practice, DAG-CBOR can often be significantly more compact than JSON,
+due to the densely packed binary coding.
+(Numbers are often smaller; booleans are single bytes instead of four or five;
+strings don't gain bytes when content needs escaping; etc.)
+Note that this is highly data-dependent; your mileage may vary.
+
+DAG-CBOR will especially compare favorably to JSON or DAG-JSON when it comes to binary content.
+In DAG-JSON and typical JSON systems, binary content is base64 encoded, which results in 33% expansion.
+In DAG-CBOR there is no such expansion.
+
+### simplicity
+
+CBOR, and thus DAG-CBOR, is reasonably simple to implement, and well-specified.
+
+Care should be taken around some details of DAG-CBOR which are subsets of CBOR.
+For example, canonical DAG-CBOR should always use length prefixes,
+even though CBOR supports an "indefinite length" mode for maps and lists.
+
+CBOR includes some bit-wrangling to implement,
+because kind indicators and length indicators are combined into a single byte when lengths are small.
+This mechanism is well specified and generally considered easy to implement.
+
+CBOR does not require any escaping routines to be implemented;
+the length prefix parsing is sufficient instead.
+This makes CBOR easier to implement than encoding systems that do require escaping mechanisms
+(as well as rules out the possibility of security issues arising from incorrectly implemented escaping).


### PR DESCRIPTION
Expand the brief notes in the docs that overview DAG-CBOR to have more remarks on density, and add remarks on complexity.

These are thanks to a series of prompts and comments from @ianopolous.