### PR TITLE
Replaces Slack and Matrix links with Discord.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,7 @@ Finding Us
 ----------
 
 - For chats with the developers and the community: Join us in any of these (bridged) locations:
-	- On Matrix: https://matrix.to/#/#ipld:ipfs.io
-	- On Discord: join the larger IPFS community at https://discord.gg/FsBu3XdjKP, then find an `#ipld` channel within!
+    - On Discord: join the IPLD community at https://discord.gg/xkUC8bqSCP
 	- On IRC: (bridge coming soon) (note that we no longer use the freenode network!)
 - On Github:
 	- Check out all our repos in the https://github.com/ipld/ organization.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Finding Us
 ----------
 
 - For chats with the developers and the community: Join us in any of these (bridged) locations:
-    - On Discord: join the IPLD community at https://discord.gg/xkUC8bqSCP
+    - On Discord: join the [IPLD community on IPFS Discord](https://discord.gg/xkUC8bqSCP).
 	- On IRC: (bridge coming soon) (note that we no longer use the freenode network!)
 - On Github:
 	- Check out all our repos in the https://github.com/ipld/ organization.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Finding Us
 
 - For chats with the developers and the community: Join us in any of these (bridged) locations:
     - On Discord: join the [IPLD community on IPFS Discord](https://discord.gg/xkUC8bqSCP).
+    - On Matrix: [#ipld:ipfs.io](https://matrix.to/#/#ipld:ipfs.io)
 - On Github:
 	- Check out all our repos in the https://github.com/ipld/ organization.
 	- Github issues can be used for discussing designs, documenting user needs, and submitting bug reports.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ Finding Us
 
 - For chats with the developers and the community: Join us in any of these (bridged) locations:
     - On Discord: join the [IPLD community on IPFS Discord](https://discord.gg/xkUC8bqSCP).
-	- On IRC: (bridge coming soon) (note that we no longer use the freenode network!)
 - On Github:
 	- Check out all our repos in the https://github.com/ipld/ organization.
 	- Github issues can be used for discussing designs, documenting user needs, and submitting bug reports.

--- a/docs/intro/community.md
+++ b/docs/intro/community.md
@@ -16,6 +16,7 @@ helping us improve our community.
 
 - For chats with the developers and the community: Join us in any of these (bridged) locations:
 	- On Discord: join the [IPLD community on IPFS Discord](https://discord.gg/xkUC8bqSCP).
+	- On Matrix: [#ipld:ipfs.io](https://matrix.to/#/#ipld:ipfs.io)
 	- On IRC: (bridge coming soon) (note that we no longer use the freenode network!)
 
 ### Development

--- a/docs/intro/community.md
+++ b/docs/intro/community.md
@@ -15,8 +15,7 @@ helping us improve our community.
 ### Chat
 
 - For chats with the developers and the community: Join us in any of these (bridged) locations:
-	- On Matrix: https://matrix.to/#/#ipld:ipfs.io
-	- On Discord: join the larger IPFS community at https://discord.gg/FsBu3XdjKP, then find an `#ipld` channel within!
+	- On Discord: join the IPLD community at https://discord.gg/xkUC8bqSCP
 	- On IRC: (bridge coming soon) (note that we no longer use the freenode network!)
 
 ### Development

--- a/docs/intro/community.md
+++ b/docs/intro/community.md
@@ -15,7 +15,7 @@ helping us improve our community.
 ### Chat
 
 - For chats with the developers and the community: Join us in any of these (bridged) locations:
-	- On Discord: join the IPLD community at https://discord.gg/xkUC8bqSCP
+	- On Discord: join the [IPLD community on IPFS Discord](https://discord.gg/xkUC8bqSCP).
 	- On IRC: (bridge coming soon) (note that we no longer use the freenode network!)
 
 ### Development


### PR DESCRIPTION
As per https://github.com/protocol/docs/issues/9, replaces old and dull Slack and Matrix links with brand new and shiny Discord links.