### PR TITLE
Patch spec

### DIFF
--- a/specs/patch/fixtures/fixtures-1.md
+++ b/specs/patch/fixtures/fixtures-1.md
@@ -1,0 +1,89 @@
+Patch Fixtures 1
+================
+
+This file contains a bunch of fixtures for the Patch system.
+These are suitable both as mechanical test fixtures, and as examples for humans.
+
+### What's covered?
+
+All the fixtures in this file are operating on single blocks --
+the data can still be a tree (maps, lists, etc), but contains no links.
+(Other fixtures cover data that spans multiple blocks by use of links.)
+
+### What's the fixture format?
+
+This is the [testmark format](https://github.com/warpfork/go-testmark);
+it can be consumed programmatically.
+(Note that you probably _can't_ see these labels as this page is rendered on ts.
+
+### This doesn't have to be JSON!
+
+We've used JSON here for the initial data, as well as the patch instructions and the results.
+However, this is a totally stylistic choice.  We're just using JSON here because it's convenient and it's human-readable.
+You can equally well express all of these objects in CBOR, or other [codecs](/docs/codecs/); it makes no difference to IPLD.
+The patch instruction and the subject data don't even have to be in the same codec, either.
+
+
+Fixtures
+--------
+
+### Adding an entry to a map
+
+Given an initial document:
+
+[testmark]:# (adding-a-map-entry/initial)
+```json
+{"foo": "bar"}
+```
+   
+and a Patch OperationSequence:
+
+[testmark]:# (adding-a-map-entry/patch)
+```json
+[
+	{ "op": "add", "path": "/baz", "value": "qux" }
+]
+```
+
+The following document should result:
+
+[testmark]:# (adding-a-map-entry/result)
+```json
+{
+	"foo": "bar",
+	"baz": "qux"
+}
+```
+
+Note that if order is sensitive, the additions are considered to go at the end of map.
+
+
+### Inserting into a list
+
+Given an initial document:
+
+[testmark]:# (inserting-into-a-list/initial)
+```json
+["bar", "baz"]
+```
+   
+and a Patch OperationSequence:
+
+[testmark]:# (inserting-into-a-list/patch)
+```json
+[
+	{ "op": "add", "path": "/1", "value": "qux" }
+]
+```
+
+The following document should result:
+
+[testmark]:# (inserting-into-a-list/result)
+```json[
+[
+	"bar",
+	"qux",
+	"baz"
+]
+```
+

--- a/specs/patch/fixtures/fixtures-1.md
+++ b/specs/patch/fixtures/fixtures-1.md
@@ -281,3 +281,45 @@ The following document should result:
 	"bar": "zar"
 }
 ```
+
+
+### Testing and conditional modification - Failing case
+
+Given an initial document:
+
+[testmark]:# (test-and-conditional-fail/initial)
+```json
+{
+	"baz": "qux",
+	"foo": [
+		"a",
+		2,
+		"c"
+	]
+}
+```
+
+and a Patch OperationSequence:
+
+[testmark]:# (test-and-conditional-fail/patch)
+```json
+[
+	{ "op": "test", "path": "/baz", "value": "qux" },
+	{ "op": "test", "path": "/foo/1", "value": 3 },
+	{ "op": "add",  "path": "/bar", "value": "zar" }
+]
+```
+
+The operation should abort and the document should remain as:
+
+[testmark]:# (test-and-conditional-fail/result)
+```json
+{
+	"baz": "qux",
+	"foo": [
+		"a",
+		2,
+		"c"
+	]
+}
+```

--- a/specs/patch/fixtures/fixtures-1.md
+++ b/specs/patch/fixtures/fixtures-1.md
@@ -80,7 +80,7 @@ and a Patch OperationSequence:
 The following document should result:
 
 [testmark]:# (inserting-into-a-list/result)
-```json[
+```json
 [
 	"bar",
 	"qux",
@@ -113,7 +113,7 @@ and a Patch OperationSequence:
 The following document should result:
 
 [testmark]:# (removing-map-entry/result)
-```json[
+```json
 {
 	"foo": "bar"
 }
@@ -144,7 +144,7 @@ and a Patch OperationSequence:
 The following document should result:
 
 [testmark]:# (replacing-map-entry/result)
-```json[
+```json
 {
 	"baz": "boo",
 	"foo": "bar"
@@ -181,7 +181,7 @@ and a Patch OperationSequence:
 The following document should result:
 
 [testmark]:# (copy/result)
-```json[
+```json
 {
 	"foo": {
 		"bar": "baz",
@@ -224,7 +224,7 @@ and a Patch OperationSequence:
 The following document should result:
 
 [testmark]:# (move/result)
-```json[
+```json
 {
 	"foo": {
 		"bar": "baz"
@@ -270,7 +270,7 @@ The add operation should only apply if the test operations yield true.)
 The following document should result:
 
 [testmark]:# (test-and-conditional-modify/result)
-```json[
+```json
 {
 	"baz": "qux",
 	"foo": [

--- a/specs/patch/fixtures/fixtures-1.md
+++ b/specs/patch/fixtures/fixtures-1.md
@@ -235,3 +235,49 @@ The following document should result:
 	}
 }
 ```
+
+
+### Testing and conditional modification
+
+Given an initial document:
+
+[testmark]:# (test-and-conditional-modify/initial)
+```json
+{
+	"baz": "qux",
+	"foo": [
+		"a",
+		2,
+		"c"
+	]
+}
+```
+
+and a Patch OperationSequence:
+
+[testmark]:# (test-and-conditional-modify/patch)
+```json
+[
+	{ "op": "test", "path": "/baz", "value": "qux" },
+	{ "op": "test", "path": "/foo/1", "value": 2 },
+	{ "op": "add",  "path": "/bar", "value": "zar" }
+]
+```
+
+(Note that this contains both test operations as well as a subsequent add operation!
+The add operation should only apply if the test operations yield true.)
+
+The following document should result:
+
+[testmark]:# (test-and-conditional-modify/result)
+```json[
+{
+	"baz": "qux",
+	"foo": [
+		"a",
+		2,
+		"c"
+	],
+	"bar": "zar"
+}
+```

--- a/specs/patch/fixtures/fixtures-1.md
+++ b/specs/patch/fixtures/fixtures-1.md
@@ -19,9 +19,9 @@ you'll have to find the markdown [source](/specs/about/#source).)
 
 ### This doesn't have to be JSON!
 
-We've used JSON here for the initial data, as well as the patch instructions and the results.
+We've used JSON (representing the DAG-JSON format) here for the initial data, as well as the patch instructions and the results.
 However, this is a totally stylistic choice.  We're just using JSON here because it's convenient and it's human-readable.
-You can equally well express all of these objects in CBOR, or other [codecs](/docs/codecs/); it makes no difference to IPLD.
+You can equally well express all of these objects in DAG-CBOR, or other [codecs](/docs/codecs/); it makes no difference to IPLD.
 The patch instruction and the subject data don't even have to be in the same codec, either.
 
 

--- a/specs/patch/fixtures/fixtures-1.md
+++ b/specs/patch/fixtures/fixtures-1.md
@@ -14,7 +14,8 @@ the data can still be a tree (maps, lists, etc), but contains no links.
 
 This is the [testmark format](https://github.com/warpfork/go-testmark);
 it can be consumed programmatically.
-(Note that you probably _can't_ see these labels as this page is rendered on ts.
+(Note that you probably _can't_ see these labels as this page is rendered on the website;
+you'll have to find the markdown [source](/specs/about/#source).)
 
 ### This doesn't have to be JSON!
 
@@ -66,7 +67,7 @@ Given an initial document:
 ```json
 ["bar", "baz"]
 ```
-   
+
 and a Patch OperationSequence:
 
 [testmark]:# (inserting-into-a-list/patch)
@@ -87,3 +88,33 @@ The following document should result:
 ]
 ```
 
+
+### Removing an entry from a map
+
+Given an initial document:
+
+[testmark]:# (removing-map-entry/initial)
+```json
+{
+	"baz": "qux",
+	"foo": "bar"
+}
+```
+
+and a Patch OperationSequence:
+
+[testmark]:# (removing-map-entry/patch)
+```json
+[
+	{ "op": "remove", "path": "/baz" }
+]
+```
+
+The following document should result:
+
+[testmark]:# (removing-map-entry/result)
+```json[
+{
+	"foo": "bar"
+}
+```

--- a/specs/patch/fixtures/fixtures-1.md
+++ b/specs/patch/fixtures/fixtures-1.md
@@ -118,3 +118,120 @@ The following document should result:
 	"foo": "bar"
 }
 ```
+
+
+### Replacing an entry from a map
+
+Given an initial document:
+
+[testmark]:# (replacing-map-entry/initial)
+```json
+{
+	"baz": "qux",
+	"foo": "bar"
+}
+```
+
+and a Patch OperationSequence:
+
+[testmark]:# (replacing-map-entry/patch)
+```json
+[
+	{ "op": "replace", "path": "/baz", "value": "boo" }
+]
+```
+
+The following document should result:
+
+[testmark]:# (replacing-map-entry/result)
+```json[
+{
+	"baz": "boo",
+	"foo": "bar"
+}
+```
+
+
+### Copying a value
+
+Given an initial document:
+
+[testmark]:# (copy/initial)
+```json
+{
+	"foo": {
+		"bar": "baz",
+		"waldo": "fred"
+	},
+	"qux": {
+		"corge": "grault"
+	}
+}
+```
+
+and a Patch OperationSequence:
+
+[testmark]:# (copy/patch)
+```json
+[
+	{ "op": "copy", "from": "/foo/waldo", "path": "/qux/thud" }
+]
+```
+
+The following document should result:
+
+[testmark]:# (copy/result)
+```json[
+{
+	"foo": {
+		"bar": "baz",
+		"waldo": "fred"
+	},
+	"qux": {
+		"corge": "grault",
+		"thud": "fred"
+	}
+}
+```
+
+
+### Moving a value
+
+Given an initial document:
+
+[testmark]:# (move/initial)
+```json
+{
+	"foo": {
+		"bar": "baz",
+		"waldo": "fred"
+	},
+	"qux": {
+		"corge": "grault"
+	}
+}
+```
+
+and a Patch OperationSequence:
+
+[testmark]:# (move/patch)
+```json
+[
+	{ "op": "move", "from": "/foo/waldo", "path": "/qux/thud" }
+]
+```
+
+The following document should result:
+
+[testmark]:# (move/result)
+```json[
+{
+	"foo": {
+		"bar": "baz"
+	},
+	"qux": {
+		"corge": "grault",
+		"thud": "fred"
+	}
+}
+```

--- a/specs/patch/fixtures/index.md
+++ b/specs/patch/fixtures/index.md
@@ -1,0 +1,11 @@
+---
+title: "IPLD Patch Test Fixtures"
+eleventyNavigation:
+  synopsys: "Fixtures to be used to help determine specification compliance for implementations"
+---
+
+IPLD Patch Test Fixtures
+==========
+
+{% import "listing.njk" as listing %}
+{{ listing.childrenTableWithSynopsys(collections.all, page.url) }}

--- a/specs/patch/index.md
+++ b/specs/patch/index.md
@@ -1,0 +1,32 @@
+---
+title: "IPLD Patch Specs"
+navTitle: "Patch"
+eleventyNavigation:
+  order: 70
+  synopsys: "A declarative Patch system (based on JSON Patch) exists for working with IPLD."
+---
+
+IPLD Patch
+==========
+
+IPLD Patch is a system for declaratively specifying patches to a document, which can then be applied to produce a new, modified document.
+
+IPLD Patch is roughly based on the [JSON Patch (RFC 6902)](https://datatracker.ietf.org/doc/html/rfc6902/) specification -- it should feel very familiar.
+
+For the full details, see the [Fixtures](./fixtures/) -- the test fixture material is both for implementers, but also for end users, and provides rich examples and explanatory notes.
+
+In brief highlights:
+
+- There are six operations -- add, replace, remove, copy, move, test.
+  - (This is the same as RFC 6902.)
+- Operations are supplied in a list, and applied linearly.  Any operation erroring results in the entire patch not being applied.
+  - (This is the same as RFC 6902.)
+- Operations do not create parent paths automatically.
+  - (This is the same as RFC 6902.)
+- Because this is IPLD, both the subject data, as well as the patch instructions themselves, can be communicated in any codec.
+  (e.g. you can easily serialize a patch in [CBOR](/docs/codecs/known/dag-cbor), and apply it to a document encoded in [dag-pb](/docs/codecs/known/dag-pb), and so on).
+- Furthermore: because the Patch system is specified over the IPLD [Data Model](/docs/data-model/), you can expect it to work over other layers as well --
+  for example, Patches can be applied over data processed with [Schemas](/docs/schemas/) or [ADLs](/docs/advanced-data-layouts/).
+- The Patch system in IPLD is expected to maintain order whenever possible.  Wherever this is ambiguous (e.g. operations adding data to a map under a key that didn't previously exist), operations are defined as appending to the end of the relevant node.
+
+See the [Fixtures](./fixtures/) for more details.


### PR DESCRIPTION
Introducing a "patch" system, and defining it by fixtures!

This is roughly following the [JSON Patch (RFC 6902)](https://datatracker.ietf.org/doc/html/rfc6902/) specification -- It's a very decent specification.  (Most of the fixtures here also come from its examples appendix, sometimes with minor modifications.)

In brief highlights:
- There are six operations -- add, replace, remove, copy, move, test.
  - (This is the same as RFC 6902.)
- Operations are supplied in a list, and applied linearly.  Any operation erroring results in the entire patch not being applied.
  - (This is the same as RFC 6902.)
- Operations do not create parent paths automatically.
  - (This is the same as RFC 6902.)
  - (I think we may want to add ways to support this succinctly in the future!)
- Note there is no "upsert" operation.
  - (This is the same as RFC 6902.)
  - (I think we may want to add ways to support this succinctly in the future!)
- All of these fixtures are JSON -- but of course, because this is IPLD, both the subject data, as well as the patch instructions themselves, can be communicated in any codec (e.g. CBOR, or dag-pb (... for the subject data anyway), or etc).
- Note that we do *not* follow RFC 6902's [escaping rules](https://datatracker.ietf.org/doc/html/rfc6902/#appendix-A.14) (which appear to be from [RFC 6901](https://datatracker.ietf.org/doc/html/rfc6901#section-3), although this is not explicitly stated).  The opinion among us who did an early design review for this system was that the escaping mechanism shown there is very unusual, and would surprise most users, and thus we will not replicate it.
- Note that a Patch system in IPLD is expected to maintain order whenever possible.  Wherever this is ambiguous (e.g. operations adding data to a map under a key that didn't previously exist), operations are defined as appending to the end of the relevant node.  This results in some of our fixtures being mildly divergent from RFC 6902 (which appears to treat map order as inconsequential).  We consider this important to specify for determinism reasons.

There is a matching implementation, which exercises these fixtures, found in https://github.com/ipld/go-ipld-prime/pull/350 .