### PR TITLE
exploration report: lens combinators

### DIFF
--- a/notebook/exploration-reports/2022.03-lens-combinators.md
+++ b/notebook/exploration-reports/2022.03-lens-combinators.md
@@ -1,0 +1,164 @@
+Lens Combinators: a proposal for extensible declarative signalling of advanced IPLD features
+============================================================================================
+
+**Author**: Eric Myhre ([@warpfork])
+
+---
+
+A brief example of why there's something to do here:
+
+Here's an instruction I wish we could give to a patch API:
+
+First, using just one ADL:
+
+```
+{"patch": {
+  "startAt": "bafybayetc1",
+  "operations": [
+    {"op": "add", "path": "/foobarbaz/thingy/whatnot", "value": {"things": "here"}},
+  ],
+  "lens": {"adl": {"HAMTv1"}}
+}}
+```
+
+Above: there's just one lens, it's an ADL by name, and implicitly it starts applying at the root.
+
+Below: similar idea, but "atPaths" is going to be a LensCombinator object, and it's signalling that two other lenses should be used at various paths within the data.
+
+```
+{"patch": {
+  "startAt": "bafybayetc1",
+  "operations": [
+    {"op": "add", "path": "/foobarbaz/thingy/whatnot", "value": {"things": "here"}},
+  ],
+  "lens": {"atPaths":{
+    "/foobarbaz": {"adl": "HAMTv1"},
+    "/foobarbaz/thingy": {"schema": {"schema":"bafycidofschema", "startype":"Foobar"}}
+  }}
+}}
+```
+
+What do we gain, with the lens combinator?  Several things:
+
+- Pure conceptually: schemas and ADLs have been unified into the concept of "lenses".  (This seems like an architectural win!)
+- We can signal the use of a lens at paths _other than the root_.  More flexible.
+- We can signal the use of _more than one_ lens, at _different positions_ in the data.
+- (Not shown, yet, but imagine it) We can use the lens combinator to override our way *back out* of a lens:
+	- Imagine a schema that says we have some recursive type called "Dir" that uses a HAMT ADL at each occurrence... but in one position, several recursions deep, we actually want to *cancel* that lens and see the raw data again.  A lens combinator gives us a place to express such a thing.
+- We gain an extension point.  (If more lensing systems are invented in the future, it becomes clear where to plug them in.)
+- This becomes a standard that we can reuse in any API that regards data or pathing over it: so, in the Patch API; in plain old regular GET requests; in the use of Selectors; it could be used as configuration for the IPLD Explorer to engage all these features, and combinations of them, at once; etc.
+
+
+Considerations
+--------------
+
+### Extensibility
+
+The concept itself is quite extensible.
+
+In the examples above, the `"lens"` field is clearly describable as a keyed union.
+(The exercise is left to the reader.)
+
+Extending this with further kinds of lenses (if we invent more of them),
+or extending it with other forms of combinator (e.g. perhaps some that are not purely path based),
+should be simply a matter of adding more members to the union over time.
+
+Not only would we be free to introduce more combinators over time,
+this system would actually open the door to allowing, say, more than one kind of schema system to exist.
+(They'd all just be lenses!)
+
+### We already have most of these concepts in place
+
+... this is just sort of stating them even more explicitly.
+
+It's already the case that:
+
+- all data in the ("raw") data model (e.g., what codecs give you) can be read and pathed over through one universal interface;
+- all data that has been unified with a Schema can be read at the type level and pathed over through the same universal interface;
+- all the data that an ADL munged into one coherent view can be read and pathed over through that same universal interface.
+
+Giving a name -- "lens" -- to any of these things that support interactions via the universal interface... it just makes sense.
+
+### Interaction with other Signalling Systems
+
+"Signalling" is a recurring theme,
+which has previously been long discussed especially [in the context of ADLs](/docs/advanced-data-layouts/signalling/).
+Lens combinators are also performing the job of signalling.
+
+Signalling features have already been introduced in the IPLD universe in some other specific places.
+One example is in IPLD Selectors, where the `InterpretAs` clause can name an ADL to use at the current position in the walk that the Selector is guiding.
+It has also long been proposed that IPLD Schemas should be able to signal an ADL to use whenever some type is expected
+(although the exact details and syntax for that have been contested over time, and I don't know if an end-to-end working demo has ever been shipped).
+
+This proposal of lens combinators is arguably competitive to such other signalling systems -- but there is room for both to coexist,
+and different systems may be suitable in different contexts.
+
+Here is a sampling of things which vary between the various extant and proposed signalling systems seen so far:
+
+- Lens combinators (in particular the "atPaths" proposal in the initial example) have the notable feature of describing what lenses to invoke at paths at some distance from the start.
+	- Neither the Selector `InterpretAs` system nor proposed Schema features support this; they're both focused on applying signals at some current position within their own internal navigation concepts.
+- Lens combinators are meant to combine any lenses, freely.
+	- The Selector `InterpretAs` system is (at present?) only for ADL invocation.  Schemas also only have an interest in describing what ADL to invoke for understanding a type.
+- Lens combinators don't have an active recursion concept of their own (although they can be used recursively; a lens combinator is a lens).
+	- By contrast: Selectors and Schemas both describe systems that contain recursion.  (Selectors have clauses explicitly describing recursions; Schemas can have e.g. `type Foo [Foo]`.)
+- Lens combinators offer the ability to disengage one lens and engage another after some number of strides across data using the first lens.
+	- ADLs don't generally have (nor need) such a concept; you apply them at once place, and they return plain data model and that's the end.
+	- Schemas don't offer a disengage mechanism.  Once something is described by a schema, all further strides are still advised by the lens of the schema type system.
+	- Selectors sorta offer a disengage mechanism; their recursion systems always have a limit.  It's debatable whether this is contextually easy to use, though.
+
+These systems could co-exist, and even end up handing off to each other in useful ways.
+For example, a Schema (which is now a lens) might specify an
+
+### Implementation
+
+(There will surely be more than one different approach to implementing this concept;
+however, here are some thoughts nonetheless.)
+
+Lenses seem like they should be a good fit to implementation as a stack of Node interfaces:
+the Node on the bottom of the stack is raw data model (e.g. the sort of stuff produced by a codec),
+another Node atop that might wrap it with Schema type behavior and data transformation;
+and another Node atop that might track the information from an "atPaths" lens combinator declaration.
+
+In that example, the top Node in stack, the lens combinator one,
+is mostly just delegating and passing through the information from the layer below, unchanged...
+
+... Up until, that is, the point where a stride across the data hits a path where the lens combinator declaration
+states a different lens should now be used.
+Then the internal delegation logic changes.
+
+Implementing this efficiently might be a bit [Fun](http://dwarffortresswiki.org/index.php/Fun).
+Reconciling it with immutable nodes is a difficult idea.
+
+Implementation using an object in memory for each Node is possible,
+but will probably provoke many small allocations.
+(E.g., if one had already taken this approach for the bottommost layer, and one then has a stack of depth three as in the example above,
+one is going to end up with 3x that already-considerable number of allocations.
+Considering that when optimizing for high performance, we've already put considerable work in some of our libraries
+to produce less than that amount of small allocations on the bottommost layer, I'm not sure that that cost multiplier would be always acceptable.)
+
+It also seems that the Node (at least for the "atPaths" lens combinator) ends up needing to remember where it is in the current pathing.
+(Either that, or the library API forces the developer to hold onto both a path and the node at the same time, and provide the full path to all strides,
+which seems roughly the same in result but more unpleasant and error-prone to use as an API.)
+
+It may be worth trying to design a library around some kind of "cursor"-like design concept,
+which could attempt to avoid allocation by having the stack of logical controllers,
+but roving around the underlying data without allocating objects to track each position.
+However, this author struggles to imagine a way to reconcile this idea with an API that also prioritizes immutability.
+
+### Doesn't this make it even harder to put this stuff in a URL?
+
+Ugh!  It does!  And we would, ideally, like to have an idea of how we'd describe some of this stuff in a URL,
+because we'd like to a reasonably standard way to provide lens descriptions to things like e.g the IPLD Explorer; other APIs; etc.
+
+Whereas we might've previously considered adding specific information to GET requests as parameters encoded in a URL --
+say, `?schema=bafycidofschema&starttype=Foobar`...
+
+... now we would have something like `?lens=%7B%22schema%22%3A%7B%22schema%22%3A%22bafycidofschema%22%2C%22startype%22%3A%22Foobar%22%7D%7D`.
+That's gnarly.  (This is taking the JSON structure seen in earlier examples and URLencoding the JSON.)
+
+There may be cleverer ways to go about this that are less gnarly.
+(URLencoded JSON is only used as an example; it is probably not the most visually clean option.)
+The fundamental disconnect here is probably more about recursive structures needing to be flattened into k/v pairs,
+rather than any particular codec and its escaping, though.
+
+Clever ideas wanted, here.


### PR DESCRIPTION
This is a brief exploration of some ideas about how we could declaratively specify the use of Schemas, ADLs, and even have an extension path to other as-yet-uninvented data transformation mechanisms.

In it, Schemas and ADLs are both reframed as "lenses", and another new "lens" is also proposed: a simple "lens combinator", which allows invoking other lenses at various paths within some data.

Examples of using it as part of a Patch API are included, but the concept is meant to be reusable and drop-in in other scenarios as well.