### PR TITLE
chore: add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'monthly'
+    commit-message:
+      prefix: 'chore'
+      include: 'scope'


### PR DESCRIPTION
Adding a monthly check so it doesn't get too noisy; there's a package-lock.json in here so it's going to get pretty picky. There's currently a security alert in this repo thanks to something in package-lock.json being out of date.