### PR TITLE
docs: Rearrange media on front page

### DIFF
--- a/index.njk
+++ b/index.njk
@@ -205,19 +205,19 @@ layout:
     </p>
     <div class="cf ph2-ns">
       <div class="fl w-100 w-60-l ph2 pr4-l pv3">
-        {% youtube id="Sgf6j_mCdjI", caption="ResNetLab: Intro to InterPlanetary Linked Data" %}
+        {% youtube id="totVQXYS1N8", caption="GPN19 - Foundations for Decentralization: Data with IPLD" %}
       </div>
       <div class="fl w-50 w-25-m w-20-l ph2 pv3">
         {% youtubePreview id="Bqs_LzBjQyk", caption="Juan Benet: Enter the Merkle Forest" %}
       </div>
       <div class="fl w-50 w-25-m w-20-l ph2 pv3">
-        {% youtubePreview id="bi-4YGZXxwA", caption="Jeromy Johnson Shares IPFS Blockchain Fun" %}
+        {% youtubePreview id="Sgf6j_mCdjI", caption="ResNetLab: Intro to InterPlanetary Linked Data" %}
       </div>
       <div class="fl w-50 w-25-m w-20-l ph2 pv3">
         {% youtubePreview id="skMTdSEaCtA", caption="Why We Must Distribute The Web" %}
       </div>
       <div class="fl w-50 w-25-m w-20-l ph2 pv3">
-        {% youtubePreview id="Pjyo2uILcOs", caption="Martin Becze: Interplanetary OS" %}
+        {% youtubePreview id="Y_-TWTmF_1I", caption="How IPFS Deals With Files - IPFS Camp Workshop" %}
       </div>
     </div>
   </div>


### PR DESCRIPTION
Closes #108 

Adds Eric's talk [Foundations for Decentralization: Data with IPLD](https://www.youtube.com/watch?v=totVQXYS1N8) as the main focus of the homepage videos

Replaces the Interplanetary OS video with the "How IPFS Deals with Files" from IPFS Camp: https://www.youtube.com/watch?v=Y_-TWTmF_1I