### PR TITLE
Add MultihashIndexSorted to table of content

### DIFF
--- a/specs/transport/car/carv2/index.md
+++ b/specs/transport/car/carv2/index.md
@@ -17,6 +17,7 @@ eleventyNavigation:
   * [Index payload](#index-payload)
   * [Index format](#index-format)
     * [Format `0x0400`: IndexSorted](#format-0x0400-indexsorted)
+    * [Format `0x0401`: MultihashIndexSorted](#format-0x0401-multihashindexsorted)
 * [Implementations](#implementations)
 * [Test Fixtures](#test-fixtures)
 


### PR DESCRIPTION
Update the CarV2 spec table of content with link to
`MultihashIndexSorted`.