### PR TITLE
Fix broken .md links when viewed as markdown

### DIFF
--- a/.site/.eleventy.js
+++ b/.site/.eleventy.js
@@ -41,9 +41,16 @@ module.exports = function (eleventyConfig) {
   // Inspired by https://github.com/11ty/eleventy/issues/1204
   const replaceLocalMdLinks = function(link, env) {
     const matcher = new RegExp('^(\./|\.\./|/)(.*?)(.md)(\#.*?)?$');
-    return matcher.test(link) ?
-      link.replace(matcher, "$1$2$4") :
-      link;
+    if (matcher.test(link)) {
+      // Pages with file name index.md are output at a different level in the
+      // directory hierarchy than other pages so we need to fix up relative links
+      // in those pages to their siblings so they connect.
+      const indexPage = env.page.inputPath.endsWith("/index.md");
+      const translatedLink = link.replace(matcher, "$1$2$4");
+      return indexPage ? translatedLink : translatedLink.replace(/^\.\/(.*?)/, "../$1")
+    } else {
+      return link;
+    }
   }
 
   const markdownLibrary = markdownIt({

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "markdown-it-container": "^3.0.0",
         "markdown-it-footnote": "^3.0.3",
         "markdown-it-mark": "^3.0.1",
+        "markdown-it-replace-link": "^1.1.0",
         "markdown-it-table-of-contents": "^0.6.0",
         "run-script-os": "^1.1.6"
       }
@@ -2197,6 +2198,12 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/markdown-it-mark/-/markdown-it-mark-3.0.1.tgz",
       "integrity": "sha512-HyxjAu6BRsdt6Xcv6TKVQnkz/E70TdGXEFHRYBGLncRE9lBFwDNLVtFojKxjJWgJ+5XxUwLaHXy+2sGBbDn+4A==",
+      "dev": true
+    },
+    "node_modules/markdown-it-replace-link": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-replace-link/-/markdown-it-replace-link-1.1.0.tgz",
+      "integrity": "sha512-P+4D/Z16utgQVjMumA5W3lMbxWYk4iwg1Fk59wShFm7MRgzbjJm++tvI18LdYwiG8CKNA1TFWvHcbtehvMuViA==",
       "dev": true
     },
     "node_modules/markdown-it-table-of-contents": {
@@ -5563,6 +5570,12 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/markdown-it-mark/-/markdown-it-mark-3.0.1.tgz",
       "integrity": "sha512-HyxjAu6BRsdt6Xcv6TKVQnkz/E70TdGXEFHRYBGLncRE9lBFwDNLVtFojKxjJWgJ+5XxUwLaHXy+2sGBbDn+4A==",
+      "dev": true
+    },
+    "markdown-it-replace-link": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-replace-link/-/markdown-it-replace-link-1.1.0.tgz",
+      "integrity": "sha512-P+4D/Z16utgQVjMumA5W3lMbxWYk4iwg1Fk59wShFm7MRgzbjJm++tvI18LdYwiG8CKNA1TFWvHcbtehvMuViA==",
       "dev": true
     },
     "markdown-it-table-of-contents": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "markdown-it-footnote": "^3.0.3",
     "markdown-it-mark": "^3.0.1",
     "markdown-it-table-of-contents": "^0.6.0",
+    "markdown-it-replace-link": "^1.1.0",
     "run-script-os": "^1.1.6"
   }
 }

--- a/specs/codecs/dag-eth/chain.md
+++ b/specs/codecs/dag-eth/chain.md
@@ -2,7 +2,7 @@
 
 This section contains the IPLD schemas for the blockchain data structures of Ethereum.
 This includes: headers, uncle sets, transactions, and receipts. The state trie, storage trie,
-receipt trie, and transaction trie IPLDs are described in the [state](../state) section. It
+receipt trie, and transaction trie IPLDs are described in the [state](./state.md) section. It
 is important to note that traversal from header to a specific transaction or receipt requires traversal
 across their respective tries beginning at the root referenced in the header. Alternatively, uncles are referenced
 directly from the header by the hash of the RLP encoded list of uncles.

--- a/specs/codecs/dag-eth/chain.md
+++ b/specs/codecs/dag-eth/chain.md
@@ -2,7 +2,7 @@
 
 This section contains the IPLD schemas for the blockchain data structures of Ethereum.
 This includes: headers, uncle sets, transactions, and receipts. The state trie, storage trie,
-receipt trie, and transaction trie IPLDs are described in the [state](./state.md) section. It
+receipt trie, and transaction trie IPLDs are described in the [state](../state.md) section. It
 is important to note that traversal from header to a specific transaction or receipt requires traversal
 across their respective tries beginning at the root referenced in the header. Alternatively, uncles are referenced
 directly from the header by the hash of the RLP encoded list of uncles.

--- a/specs/codecs/dag-eth/chain.md
+++ b/specs/codecs/dag-eth/chain.md
@@ -2,7 +2,7 @@
 
 This section contains the IPLD schemas for the blockchain data structures of Ethereum.
 This includes: headers, uncle sets, transactions, and receipts. The state trie, storage trie,
-receipt trie, and transaction trie IPLDs are described in the [state](../state.md) section. It
+receipt trie, and transaction trie IPLDs are described in the [state](./state.md) section. It
 is important to note that traversal from header to a specific transaction or receipt requires traversal
 across their respective tries beginning at the root referenced in the header. Alternatively, uncles are referenced
 directly from the header by the hash of the RLP encoded list of uncles.

--- a/specs/codecs/dag-eth/index.md
+++ b/specs/codecs/dag-eth/index.md
@@ -20,7 +20,7 @@ For more information about the IPLD Schema language, see the [IPLD Schema docume
 
 ## Data Structure Descriptions
 
-* [Ethereum Data Structures **Basic Types**](./basic_types)
-* [Ethereum **Chain** Data Structures](./chain)
-* [Ethereum **Convenience Types**](./convenience_types)
-* [Ethereum **State** Data Structures](./state)
+* [Ethereum Data Structures **Basic Types**](./basic_types.md)
+* [Ethereum **Chain** Data Structures](./chain.md)
+* [Ethereum **Convenience Types**](./convenience_types.md)
+* [Ethereum **State** Data Structures](./state.md)


### PR DESCRIPTION
Proposed fix for : https://github.com/ipld/ipld/issues/176

I found this [11ty bug report](https://github.com/11ty/eleventy/issues/1204)  which seems to be about the same core issue. Using some of the solutions presented there as inspiration I coded up this PR which is designed to address the narrow problem of our markdown files not properly linking when accessed via GitHub web interface, or a local md-aware editor.

I have included fixups to the _md_ _files_ _themselves_ only in one area : `specs/codecs/dag-eth`. There are many more instances remaining to be changed. Figured it was best to leave them until it's clear this approach is viable.

I have manually tested the result, checking that the web site served by `yarn start` has connecting links, and the relevant pages viewed in GitHub now link correctly. `yarn test` also passes.

As a drive-by fix I also changed the `permalink` configuration for `markdown-it-anchor` because build log output warned the current code was not valid, per : https://github.com/valeriangalliat/markdown-it-anchor . I am not however at all sure if the permalink scheme I picked is what we want. The change I made cures the build warning but I don't understand enough about what we want from permalinks to know if it's the correct thing.