### PR TITLE
Update dag-cbor spec.md - swap True and False (!)

### DIFF
--- a/specs/codecs/dag-cbor/spec.md
+++ b/specs/codecs/dag-cbor/spec.md
@@ -59,8 +59,8 @@ Therefore the DAG-CBOR codec must:
      - If two keys have different lengths, the shorter one sorts earlier;
      - If two keys have the same length, the one with the lower value in (byte-wise) lexical order sorts earlier.
    * Indefinite-length items are not supported, only definite-length items are usable. This includes strings, bytes, lists and maps. The "break" token is also not supported.
-3. The only usable major type 7 minor types are those for encoding Floats (minors `25`, `26`, `27`), True (minor `20`), False (minor `21`) and Null (minor `22`).
-   * [Simple Values] other than True, False and Null are not supported. This includes all registered or unregistered simple values that are encoded with a major type 7 other than True, False and Null.
+3. The only usable major type 7 minor types are those for encoding Floats (minors `25`, `26`, `27`), False (minor `20`), True (minor `21`) and Null (minor `22`).
+   * [Simple Values] other than False, True and Null are not supported. This includes all registered or unregistered simple values that are encoded with a major type 7 other than False, True and Null.
    * Undefined (minor `23`) is not supported as it is not part of the [IPLD Data Model].
 4. Floating point values must always encoded in 64-bit, double-precision form, regardless of whether they can be represented as half (16) or single (32) precision.
 5. [IEEE 754] special values `NaN`, `Infinity` and `-Infinity` must not be accepted as they do not appear in the [IPLD Data Model]. Therefore, tokens `0xf97c00` (`Infinity`), `0xf97e00` (`NaN`) and `0xf9fc00` (`-Infinity`), their 16-bit, 32-bit and 64-bit variants, and any other [IEEE 754] byte layout that is interpreted as these values, should not appear, or be accepted in DAG-CBOR binary form.


### PR DESCRIPTION
This swaps the values to match the definitions and ordering given in RFC-8949

https://datatracker.ietf.org/doc/html/rfc8949#fpnoconttbl2

I believe this was just a typo in the dag-cbor spec, and current implementations all do what RFC-8949 *actually* says (I think, I haven't checked exhaustively)