### PR TITLE
feat(selectors): specify negative indexes in slice matching

### DIFF
--- a/specs/selectors/fixtures/selector-fixtures-1.md
+++ b/specs/selectors/fixtures/selector-fixtures-1.md
@@ -338,6 +338,79 @@ if there's several things you want in a row.
 
 ---
 
+### slice matching
+
+Matching a node that is a string or bytes can match a subset of the string or
+bytes. This is primarily helpful in the case of an ADL that reifies a complex
+representation into a simplified single string or bytes node, such as one that
+represents a multi-block bytes node as a single bytes node.
+
+#### data
+
+[testmark]:# (match-subset/data)
+```json
+"a long string that we want to match a subset of"
+```
+
+#### selector
+
+[testmark]:# (match-subset/selector)
+```json
+{
+	".": {
+		"subset": {
+			"[": 30,
+			"]": 44
+		}
+	}
+}
+```
+
+#### expected visit events
+
+[testmark]:# (match-subset/expect-visit)
+```ipldsch
+{"path": "", "node": {"string": "match a subset"}, "matched": true}
+```
+
+---
+
+### slice matching with negative indexes and extreme values
+
+Negative indexes for both "from" and "to" can be used to count from the end of
+the string or bytes node. The "to" index can be greater than the length of the
+string or bytes node, in which case it is treated as the length of the string
+or bytes node.
+
+#### data
+
+[testmark]:# (match-subset-extremities/data)
+```json
+"a long string that we want to match a subset of"
+```
+
+#### selector
+
+[testmark]:# (match-subset-extremities/selector)
+```json
+{
+	".": {
+		"subset": {
+			"[": -9,
+			"]": 9223372036854775807
+		}
+	}
+}
+```
+
+#### expected visit events
+
+[testmark]:# (match-subset-extremities/expect-visit)
+```ipldsch
+{"path": "", "node": {"string": "subset of"}, "matched": true}
+```
+
+---
 
 ### hello recursion!
 

--- a/specs/selectors/fixtures/selector-fixtures-1.md
+++ b/specs/selectors/fixtures/selector-fixtures-1.md
@@ -382,6 +382,23 @@ the string or bytes node. The "to" index can be greater than the length of the
 string or bytes node, in which case it is treated as the length of the string
 or bytes node.
 
+After adjusting "from" and "to" values to the known length of the string or
+bytes node, the following rules are applied:
+
+ * Overflow of "to" is allowed and is interpreted as the end of the slice. This
+   allows for a simple way to specify a slice from a particular index to the
+   end of the slice, without needing to know the length of the slice.
+ * Underflow of "from" is allowed (which can only occur when "from" is a
+   negative that is greater than the length of the slice), and is interpreted
+   as the beginning of the slice.
+ * Overflow of "from" and underflow of "to" are not adjusted or reinterpreted.
+   These conditions will cause the selector to fail to match anything.
+ * Where the from:to range fails to match within the byte range of the node,
+   (e.g. where they select a range beyond the end of the node), or where they
+   resolve to a negative, or zero-length range (from>=to), the selector will
+   fail to match. However, in the case where from==to, the selector will
+   match, but the matched node will be an empty string or bytes.
+
 #### data
 
 [testmark]:# (match-subset-extremities/data)
@@ -390,6 +407,9 @@ or bytes node.
 ```
 
 #### selector
+
+This selector uses the max signed 64-bit integer as the "to" index as a way to
+specify the end of the string or bytes node.
 
 [testmark]:# (match-subset-extremities/selector)
 ```json

--- a/specs/selectors/index.md
+++ b/specs/selectors/index.md
@@ -203,27 +203,32 @@ type InterpretAs struct {
 
 ## Slice is a predicate that selects only a subset of node.
 ## This is applicable primarily in the context of reified nodes based on the
-## InterpetAs clause above, where the primitive (bytes or string) node is actually
-## composed from multiple underlying substrate nodes.
+## InterpetAs clause above, where the primitive (bytes or string) node is
+## actually composed from multiple underlying substrate nodes.
 ##
-## The slice is specified by a from index, which is inclusive, and a to index,
-## which is exclusive. Overflow is allowed, in which case a reified node
-## implementation should interpret the overflow as the end of the slice. This
-## allows for a simple way to specify a slice from a particular index to the
-## end of the slice, without needing to know the length of the slice.
+## The slice is specified by a "from" index, which is inclusive, and a "to"
+## index, which is exclusive. That is: [from, to).
 ##
-## Negative values are allowed for from and to, and are interpreted as offsets
-## from the end of the slice. e.g. -1 is the last element, -2 is the second to
-## last, etc.
-## Reified node implementations may choose to not implement negative ranges due
-## to difficulties in implementing them efficiently. In these cases, the
-## selector will fail to match.
+##  * Overflow of "to" is allowed, in which case a reified node
+##    implementation should interpret the overflow as the end of the slice. This
+##    allows for a simple way to specify a slice from a particular index to the
+##    end of the slice, without needing to know the length of the slice.
 ##
-## Where the From:To range fails to match within the byte range of the node,
-## (e.g. where they select a range beyond the end of the node), or where they
-## resolve to a negative range (From>To), the selector will fail to match.
-## However, in the case where From==To, the selector will match, but the node
-## should be empty.
+##  * Negative values are allowed for "from" and "to", and are interpreted as
+##    offsets from the end of the slice. e.g. -1 is the last element, -2 is the
+##    second to last, etc. When a negative "from" value resolves to a negative
+##    index once the length of the slice is known (i.e. an underflow), the
+##    "from" value will be adjusted to be 0.
+##
+##    Reified node implementations may choose to not implement negative ranges
+##    due to difficulties in implementing them efficiently. In these cases, the
+##    selector will fail to match.
+##
+##  * Where the from:to range fails to match within the byte range of the node,
+##    (e.g. where they select a range beyond the end of the node), or where they
+##    resolve to a negative, or zero-length range (from>=to), the selector will
+##    fail to match. However, in the case where from==to, the selector will
+##    match, but the node should be empty.
 type Slice struct {
 	from Int (rename "[")
 	to Int (rename "]")

--- a/specs/selectors/index.md
+++ b/specs/selectors/index.md
@@ -205,6 +205,25 @@ type InterpretAs struct {
 ## This is applicable primarily in the context of reified nodes based on the
 ## InterpetAs clause above, where the primitive (bytes or string) node is actually
 ## composed from multiple underlying substrate nodes.
+##
+## The slice is specified by a from index, which is inclusive, and a to index,
+## which is exclusive. Overflow is allowed, in which case a reified node
+## implementation should interpret the overflow as the end of the slice. This
+## allows for a simple way to specify a slice from a particular index to the
+## end of the slice, without needing to know the length of the slice.
+##
+## Negative values are allowed for from and to, and are interpreted as offsets
+## from the end of the slice. e.g. -1 is the last element, -2 is the second to
+## last, etc.
+## Reified node implementations may choose to not implement negative ranges due
+## to difficulties in implementing them efficiently. In these cases, the
+## selector will fail to match.
+##
+## Where the From:To range fails to match within the byte range of the node,
+## (e.g. where they select a range beyond the end of the node), or where they
+## resolve to a negative range (From>To), the selector will fail to match.
+## However, in the case where From==To, the selector will match, but the node
+## should be empty.
 type Slice struct {
 	from Int (rename "[")
 	to Int (rename "]")


### PR DESCRIPTION
Note particularly the clarifying comments in specs/selectors/index.md about how `From` and `To` work, both in relation to negative indexes and positive.

After figuring out what the underlying From and To values are, taking into account the negative value adjustments:

* A From==To matches an empty node (string or bytes)
* A From>To does not match anything
* A From<0 does not match anything
* A From>End does not match anything

Negatives will _add_ to the total length of the node, such that a `-1` value takes you to the last element of the node. But because "To" is **exclusive**, a From=-2, To=-1 matches the second last byte/character of the node. There is no way to explicitly match the final byte/character of a node, but you are allowed to overflow with the To value, so From=-1 and To=MaxInt64 will give you the final character.

The `[From,To)` nature of the range is distinct from the Trustless Gateway `[From,To]` range, which presents some difficulties for translation for negative ranges. What we end up having to do is add `1` to the "To" values and in the case of `-1`, we flip it to `MaxInt64` instead of `0`.