### PR TITLE
Makefile and Glosary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ build:
 	npm run build
 
 schema-schema:
-	@ echo ">>> $@ >>>"
+	@echo ">>> $@ >>>"
 	npm run build:schema-schema
 
 dev:

--- a/docs/data-model/kinds.md
+++ b/docs/data-model/kinds.md
@@ -124,7 +124,7 @@ it takes the world as it is, and the world of strings has widely known compatibi
 
 While some codec specifications will define a required encoding it should be noted that in practice
 many codec implementations leave this kind of validation and sanitization up to the consumer (application
-code) and it is typical to find arbitrary byte data in strings even in codecs that explicitely forbid it.
+code) and it is typical to find arbitrary byte data in strings even in codecs that explicitly forbid it.
 
 Applications **SHOULD** only encode UTF8 data into string values and use byte values when they need
 arbitrary bytes, but IPLD libraries may not provide these guarantees and rely on the application, or often the

--- a/docs/data-model/pathing.md
+++ b/docs/data-model/pathing.md
@@ -33,7 +33,7 @@ A **path** is a list of **path segments**.
 Path encoding
 -------------
 
-Paths are typically seen encoded as single strings, where segments are separated by occurences of the "`/`" character.
+Paths are typically seen encoded as single strings, where segments are separated by occurrences of the "`/`" character.
 
 Beware!  The "`/`" character is also valid within a path segment.
 

--- a/docs/data-model/traversal.md
+++ b/docs/data-model/traversal.md
@@ -49,7 +49,7 @@ Iterating over a map, in the order its iterator yields entries;
 iterating over lists, in the order their iterator yields entries;
 etc.
 
-A total traversal is differenciated from a [Directed Traversal](#directed-traversal).
+A total traversal is differentiated from a [Directed Traversal](#directed-traversal).
 
 ### Directed Traversal
 
@@ -58,10 +58,10 @@ A directed traversal might visit only some of a graph,
 or might visit data in a specific order,
 based on its specific directions.
 
-A directed traversal is differenciated from a [Total Traversal](#total-traversal).
+A directed traversal is differentiated from a [Total Traversal](#total-traversal).
 
 Directed traversal is a general term and can refer to any kind of traversal one does with custom code;
-there are also some standardized features that many IPLD libraries will provide which perfrom directed traversals,
+there are also some standardized features that many IPLD libraries will provide which perform directed traversals,
 such as [Selectors](#traversal-by-selector)
 
 ### Traversal by Selector
@@ -72,7 +72,7 @@ as well as how to mark and select some of the nodes reached during that traversa
 You can think of Selectors as roughly like regexps for textual data, but made for IPLD graphs.
 
 Selectors are a form of [directed traversal](#directed-traversal).
-Accordingly, some selectors can cause the traversal to procede in a different order than a plain total traversal on the same data would have
+Accordingly, some selectors can cause the traversal to proceed in a different order than a plain total traversal on the same data would have
 (as well as, of course, traversing much _less_ data than a plain total traversal would have -- that's the point of them, after all).
 
 For an example of how the directed traversal order in selectors may differ from the norm,

--- a/glossary.md
+++ b/glossary.md
@@ -176,7 +176,6 @@ The format is described in IPLD (using [IPLD Schemas](#schemas)),
 so it's possible to serialize Selectors in any [Codec](#codec) you want,
 and it's also possible to inspect (and transform!) Selector documents using standard [Data Model](#data-model) tools.
 
-#### Signaling
 #### Signalling
 
 See the [ADL Signalling](/docs/advanced-data-layouts/signalling/) page,


### PR DESCRIPTION
* In `make schema-schema` a space between "@" and "echo" can cause issues on older versions of `make` and it's best practice not to have it
* Removed duplicate `signalling` in Glossary
* Corrected a few typos