### PR TITLE
chore: more detail & cleanup execution explanations

### DIFF
--- a/specs/transport/trustless-pathing/fixtures/unixfs_20m_variety.md
+++ b/specs/transport/trustless-pathing/fixtures/unixfs_20m_variety.md
@@ -35,7 +35,7 @@ A single-block file in the root of the UnixFS DAG, which is a single-block direc
 [testmark]:# (test/small_file_in_directory/all/execution)
 ```
 bafybeifrrglx2issn2had5rtstn3xltla6vxmpjfwfz7o3hapvkynh4zoq | Directory | /
-bafkreigtkfmisjmiqfp2y73lpqj7uu7mnqg7cjm5br67ek6nwsbyuqgkom | RawLeaf   | ↳ /pi[0:1700] (1701 B)
+bafkreigtkfmisjmiqfp2y73lpqj7uu7mnqg7cjm5br67ek6nwsbyuqgkom | RawLeaf   | ↳ /pi [0:1700] (1,701 B)
 ```
 
 #### entity
@@ -48,7 +48,7 @@ bafkreigtkfmisjmiqfp2y73lpqj7uu7mnqg7cjm5br67ek6nwsbyuqgkom | RawLeaf   | ↳ /p
 [testmark]:# (test/small_file_in_directory/entity/execution)
 ```
 bafybeifrrglx2issn2had5rtstn3xltla6vxmpjfwfz7o3hapvkynh4zoq | Directory | /
-bafkreigtkfmisjmiqfp2y73lpqj7uu7mnqg7cjm5br67ek6nwsbyuqgkom | RawLeaf   | ↳ /pi[0:1700] (1701 B)
+bafkreigtkfmisjmiqfp2y73lpqj7uu7mnqg7cjm5br67ek6nwsbyuqgkom | RawLeaf   | ↳ /pi [0:1700] (1,701 B)
 ```
 
 #### block
@@ -61,7 +61,7 @@ bafkreigtkfmisjmiqfp2y73lpqj7uu7mnqg7cjm5br67ek6nwsbyuqgkom | RawLeaf   | ↳ /p
 [testmark]:# (test/small_file_in_directory/block/execution)
 ```
 bafybeifrrglx2issn2had5rtstn3xltla6vxmpjfwfz7o3hapvkynh4zoq | Directory | /
-bafkreigtkfmisjmiqfp2y73lpqj7uu7mnqg7cjm5br67ek6nwsbyuqgkom | RawLeaf   | ↳ /pi[0:1700] (1701 B)
+bafkreigtkfmisjmiqfp2y73lpqj7uu7mnqg7cjm5br67ek6nwsbyuqgkom | RawLeaf   | ↳ /pi [0:1700] (1,701 B)
 ```
 
 ### Small file in a directory in directory in directory
@@ -79,8 +79,8 @@ Same as the above case, but the single-block file is contained within an additio
 ```
 bafybeifrrglx2issn2had5rtstn3xltla6vxmpjfwfz7o3hapvkynh4zoq | Directory | /
 bafybeigdgcs3nulbgu6vtnyesfgsaau2grbxzbxxdtpgolsfhtrpjx6mw4 | Directory | ↳ /by
-bafybeidbjnqmuizharp3piroes43frsqip37qafovv4cjok667hbdy7vhq | Directory |   ↳ /ğħōšţ
-bafkreicgd36kzadnbwjhat2eyvcbvv63a36l5oufslvryixcymnd342oei | RawLeaf   |     ↳ /Whatchamacallit.json[0:1204] (1205 B)
+bafybeidbjnqmuizharp3piroes43frsqip37qafovv4cjok667hbdy7vhq | Directory |   ↳ /by/ğħōšţ
+bafkreicgd36kzadnbwjhat2eyvcbvv63a36l5oufslvryixcymnd342oei | RawLeaf   |     ↳ /by/ğħōšţ/Whatchamacallit.json [0:1204] (1,205 B)
 ```
 
 #### entity
@@ -94,8 +94,8 @@ bafkreicgd36kzadnbwjhat2eyvcbvv63a36l5oufslvryixcymnd342oei | RawLeaf   |     �
 ```
 bafybeifrrglx2issn2had5rtstn3xltla6vxmpjfwfz7o3hapvkynh4zoq | Directory | /
 bafybeigdgcs3nulbgu6vtnyesfgsaau2grbxzbxxdtpgolsfhtrpjx6mw4 | Directory | ↳ /by
-bafybeidbjnqmuizharp3piroes43frsqip37qafovv4cjok667hbdy7vhq | Directory |   ↳ /ğħōšţ
-bafkreicgd36kzadnbwjhat2eyvcbvv63a36l5oufslvryixcymnd342oei | RawLeaf   |     ↳ /Whatchamacallit.json[0:1204] (1205 B)
+bafybeidbjnqmuizharp3piroes43frsqip37qafovv4cjok667hbdy7vhq | Directory |   ↳ /by/ğħōšţ
+bafkreicgd36kzadnbwjhat2eyvcbvv63a36l5oufslvryixcymnd342oei | RawLeaf   |     ↳ /by/ğħōšţ/Whatchamacallit.json [0:1204] (1,205 B)
 ```
 
 #### block
@@ -109,8 +109,8 @@ bafkreicgd36kzadnbwjhat2eyvcbvv63a36l5oufslvryixcymnd342oei | RawLeaf   |     �
 ```
 bafybeifrrglx2issn2had5rtstn3xltla6vxmpjfwfz7o3hapvkynh4zoq | Directory | /
 bafybeigdgcs3nulbgu6vtnyesfgsaau2grbxzbxxdtpgolsfhtrpjx6mw4 | Directory | ↳ /by
-bafybeidbjnqmuizharp3piroes43frsqip37qafovv4cjok667hbdy7vhq | Directory |   ↳ /ğħōšţ
-bafkreicgd36kzadnbwjhat2eyvcbvv63a36l5oufslvryixcymnd342oei | RawLeaf   |     ↳ /Whatchamacallit.json[0:1204] (1205 B)
+bafybeidbjnqmuizharp3piroes43frsqip37qafovv4cjok667hbdy7vhq | Directory |   ↳ /by/ğħōšţ
+bafkreicgd36kzadnbwjhat2eyvcbvv63a36l5oufslvryixcymnd342oei | RawLeaf   |     ↳ /by/ğħōšţ/Whatchamacallit.json [0:1204] (1,205 B)
 ```
 
 ### Sharded file in directory
@@ -127,13 +127,13 @@ A multi-block file in the root of the UnixFS DAG, which is a single-block direct
 [testmark]:# (test/sharded_file_in_directory/all/execution)
 ```
 bafybeifrrglx2issn2had5rtstn3xltla6vxmpjfwfz7o3hapvkynh4zoq | Directory | /
-bafybeidchppfcvpa644xihhbvbfyiqupsgp4efh4mf3pengqufwkdfrvha | File      | ↳ /želva.xml[0:1352049] (1352050 B)
-bafkreigtwsisgpg6x752y5md2z2r4jhuhohh46y4x3mvxrbkcubo7mqlgi | RawLeaf   |   ↳ /želva.xml[0:256143] (256144 B)
-bafkreigahqispwg55yvqwobavwlheongcyhk63eufsaqutqgjiwfwesfau | RawLeaf   |     /želva.xml[256144:512287] (256144 B)
-bafkreic4kgh44v2ung3wspd7y6wigcxake45ztpfx3c5ibfwmqe2kt7uay | RawLeaf   |     /želva.xml[512288:768431] (256144 B)
-bafkreibdjsvoyftwgcywb3xylnfod2wififs2tj7pww4zkvaba7z5aigtm | RawLeaf   |     /želva.xml[768432:1024575] (256144 B)
-bafkreidtv6frnbb4o4yobyu3xbtd5onzne67dhgngpd3vwrbdcneapy6fa | RawLeaf   |     /želva.xml[1024576:1280719] (256144 B)
-bafkreidy2ntimx4u22b5uy6tjh7du5ex5lhgu7comxwcjfkzfbdsdunbou | RawLeaf   |     /želva.xml[1280720:1352049] (71330 B)
+bafybeidchppfcvpa644xihhbvbfyiqupsgp4efh4mf3pengqufwkdfrvha | File      | ↳ /želva.xml [0:1352049] (1,352,050 B)
+bafkreigtwsisgpg6x752y5md2z2r4jhuhohh46y4x3mvxrbkcubo7mqlgi | RawLeaf   |   ↳ /želva.xml [0:256143] (256,144 B)
+bafkreigahqispwg55yvqwobavwlheongcyhk63eufsaqutqgjiwfwesfau | RawLeaf   |     /želva.xml [256144:512287] (256,144 B)
+bafkreic4kgh44v2ung3wspd7y6wigcxake45ztpfx3c5ibfwmqe2kt7uay | RawLeaf   |     /želva.xml [512288:768431] (256,144 B)
+bafkreibdjsvoyftwgcywb3xylnfod2wififs2tj7pww4zkvaba7z5aigtm | RawLeaf   |     /želva.xml [768432:1024575] (256,144 B)
+bafkreidtv6frnbb4o4yobyu3xbtd5onzne67dhgngpd3vwrbdcneapy6fa | RawLeaf   |     /želva.xml [1024576:1280719] (256,144 B)
+bafkreidy2ntimx4u22b5uy6tjh7du5ex5lhgu7comxwcjfkzfbdsdunbou | RawLeaf   |     /želva.xml [1280720:1352049] (71,330 B)
 ```
 
 #### entity
@@ -146,13 +146,13 @@ bafkreidy2ntimx4u22b5uy6tjh7du5ex5lhgu7comxwcjfkzfbdsdunbou | RawLeaf   |     /�
 [testmark]:# (test/sharded_file_in_directory/entity/execution)
 ```
 bafybeifrrglx2issn2had5rtstn3xltla6vxmpjfwfz7o3hapvkynh4zoq | Directory | /
-bafybeidchppfcvpa644xihhbvbfyiqupsgp4efh4mf3pengqufwkdfrvha | File      | ↳ /želva.xml[0:1352049] (1352050 B)
-bafkreigtwsisgpg6x752y5md2z2r4jhuhohh46y4x3mvxrbkcubo7mqlgi | RawLeaf   |   ↳ /želva.xml[0:256143] (256144 B)
-bafkreigahqispwg55yvqwobavwlheongcyhk63eufsaqutqgjiwfwesfau | RawLeaf   |     /želva.xml[256144:512287] (256144 B)
-bafkreic4kgh44v2ung3wspd7y6wigcxake45ztpfx3c5ibfwmqe2kt7uay | RawLeaf   |     /želva.xml[512288:768431] (256144 B)
-bafkreibdjsvoyftwgcywb3xylnfod2wififs2tj7pww4zkvaba7z5aigtm | RawLeaf   |     /želva.xml[768432:1024575] (256144 B)
-bafkreidtv6frnbb4o4yobyu3xbtd5onzne67dhgngpd3vwrbdcneapy6fa | RawLeaf   |     /želva.xml[1024576:1280719] (256144 B)
-bafkreidy2ntimx4u22b5uy6tjh7du5ex5lhgu7comxwcjfkzfbdsdunbou | RawLeaf   |     /želva.xml[1280720:1352049] (71330 B)
+bafybeidchppfcvpa644xihhbvbfyiqupsgp4efh4mf3pengqufwkdfrvha | File      | ↳ /želva.xml [0:1352049] (1,352,050 B)
+bafkreigtwsisgpg6x752y5md2z2r4jhuhohh46y4x3mvxrbkcubo7mqlgi | RawLeaf   |   ↳ /želva.xml [0:256143] (256,144 B)
+bafkreigahqispwg55yvqwobavwlheongcyhk63eufsaqutqgjiwfwesfau | RawLeaf   |     /želva.xml [256144:512287] (256,144 B)
+bafkreic4kgh44v2ung3wspd7y6wigcxake45ztpfx3c5ibfwmqe2kt7uay | RawLeaf   |     /želva.xml [512288:768431] (256,144 B)
+bafkreibdjsvoyftwgcywb3xylnfod2wififs2tj7pww4zkvaba7z5aigtm | RawLeaf   |     /želva.xml [768432:1024575] (256,144 B)
+bafkreidtv6frnbb4o4yobyu3xbtd5onzne67dhgngpd3vwrbdcneapy6fa | RawLeaf   |     /želva.xml [1024576:1280719] (256,144 B)
+bafkreidy2ntimx4u22b5uy6tjh7du5ex5lhgu7comxwcjfkzfbdsdunbou | RawLeaf   |     /želva.xml [1280720:1352049] (71,330 B)
 ```
 
 #### block
@@ -165,7 +165,7 @@ bafkreidy2ntimx4u22b5uy6tjh7du5ex5lhgu7comxwcjfkzfbdsdunbou | RawLeaf   |     /�
 [testmark]:# (test/sharded_file_in_directory/block/execution)
 ```
 bafybeifrrglx2issn2had5rtstn3xltla6vxmpjfwfz7o3hapvkynh4zoq | Directory | /
-bafybeidchppfcvpa644xihhbvbfyiqupsgp4efh4mf3pengqufwkdfrvha | File      | ↳ /želva.xml[0:1352049] (1352050 B)
+bafybeidchppfcvpa644xihhbvbfyiqupsgp4efh4mf3pengqufwkdfrvha | File      | ↳ /želva.xml [0:1352049] (1,352,050 B)
 ```
 
 ### Sharded file in directory in directory
@@ -183,25 +183,25 @@ A multi-block file nested in a single-block directory in root of the UnixFS DAG,
 ```
 bafybeifrrglx2issn2had5rtstn3xltla6vxmpjfwfz7o3hapvkynh4zoq | Directory | /
 bafybeicqlqnzd2tvs5vlo4c2dz72ryvouwmjwpu2mvxrocuj2u26joxeam | Directory | ↳ /Flibbertigibbet5
-bafybeigutoywu5bj3hlcdr4mkm6yepqnwvq5xodulrz2wstwteko2266te | File      |   ↳ /eorþscyld.pdf[0:4558477] (4558478 B)
-bafkreidz265issniggrhdjbwp3c5o4fnmg7xsa6hbn3kmyo7bsafc3jjsy | RawLeaf   |     ↳ /eorþscyld.pdf[0:256143] (256144 B)
-bafkreiepissrnjsgcanpe6hzen5kv66glcr5x5vw5vhferkjscxdj2uv3y | RawLeaf   |       /eorþscyld.pdf[256144:512287] (256144 B)
-bafkreifohr4rlzjpskbdcntrjzolglq6e5uf7n4mgdiw7wl2yhovhx46ve | RawLeaf   |       /eorþscyld.pdf[512288:768431] (256144 B)
-bafkreihiulihaonenbbtrbptmcmzcg2hvk6dypdxvmposz7ansd6h5mkla | RawLeaf   |       /eorþscyld.pdf[768432:1024575] (256144 B)
-bafkreidbhmgdt3ajzgoeywwxdbdcquone7buyenwhirl6af2z3gmftiys4 | RawLeaf   |       /eorþscyld.pdf[1024576:1280719] (256144 B)
-bafkreib6iawulrjvzet7dxbqdqneqa7kpy2kacvq7fawjvmlgveoakuzzy | RawLeaf   |       /eorþscyld.pdf[1280720:1536863] (256144 B)
-bafkreicbbl7whtfqsoz6tu663qicdisdyvzp4pp4ylggcttc44j63bdhxy | RawLeaf   |       /eorþscyld.pdf[1536864:1793007] (256144 B)
-bafkreifxe2irzoxtzk3ltpunioehodovu4pwzdtjr2lqtmkg7hyh3o5r2e | RawLeaf   |       /eorþscyld.pdf[1793008:2049151] (256144 B)
-bafkreihr2m4zfx4qvpwkp2fnihn7gbjq6gyr2gv5nbibt2nuajnp2k6pvq | RawLeaf   |       /eorþscyld.pdf[2049152:2305295] (256144 B)
-bafkreibhyumtv62kh3d4rvwpxkdlr52uur5thgmbtyuyxas3c424od7cta | RawLeaf   |       /eorþscyld.pdf[2305296:2561439] (256144 B)
-bafkreiatyvemaol2uxceo4suktpmusl53dqgg5bcqi2rkfhlxnnvpigkci | RawLeaf   |       /eorþscyld.pdf[2561440:2817583] (256144 B)
-bafkreias6ygzx2pnowi3hxj5kmed2rm74hgigwijiandz7vamvrohtkpje | RawLeaf   |       /eorþscyld.pdf[2817584:3073727] (256144 B)
-bafkreihf5g2wmsblx67664w2k3m7hj2bg2wnpumlnty7ssw4gj46oj3bxa | RawLeaf   |       /eorþscyld.pdf[3073728:3329871] (256144 B)
-bafkreib7gr6yi6lhl2p5izuxrxpknf5tc5lhkf5tdhzaxw5g66jxqichra | RawLeaf   |       /eorþscyld.pdf[3329872:3586015] (256144 B)
-bafkreigmnnfehab7c4tblwqgydbaoc76y34rkjfetayb6ytql2eywqnq5y | RawLeaf   |       /eorþscyld.pdf[3586016:3842159] (256144 B)
-bafkreiax5uhfktinmfo3ovm7geaf2266u5ya2slq4bob6eeginffbewszu | RawLeaf   |       /eorþscyld.pdf[3842160:4098303] (256144 B)
-bafkreic5chuwrtofd6ymxawcaxulacfewzfi3zroakmkwjkfmadrxrmln4 | RawLeaf   |       /eorþscyld.pdf[4098304:4354447] (256144 B)
-bafkreich7pcb4lnheypmqb4sikk5m6cuqqbxbjzuk767cx47djxac45o64 | RawLeaf   |       /eorþscyld.pdf[4354448:4558477] (204030 B)
+bafybeigutoywu5bj3hlcdr4mkm6yepqnwvq5xodulrz2wstwteko2266te | File      |   ↳ /Flibbertigibbet5/eorþscyld.pdf [0:4558477] (4,558,478 B)
+bafkreidz265issniggrhdjbwp3c5o4fnmg7xsa6hbn3kmyo7bsafc3jjsy | RawLeaf   |     ↳ /Flibbertigibbet5/eorþscyld.pdf [0:256143] (256,144 B)
+bafkreiepissrnjsgcanpe6hzen5kv66glcr5x5vw5vhferkjscxdj2uv3y | RawLeaf   |       /Flibbertigibbet5/eorþscyld.pdf [256144:512287] (256,144 B)
+bafkreifohr4rlzjpskbdcntrjzolglq6e5uf7n4mgdiw7wl2yhovhx46ve | RawLeaf   |       /Flibbertigibbet5/eorþscyld.pdf [512288:768431] (256,144 B)
+bafkreihiulihaonenbbtrbptmcmzcg2hvk6dypdxvmposz7ansd6h5mkla | RawLeaf   |       /Flibbertigibbet5/eorþscyld.pdf [768432:1024575] (256,144 B)
+bafkreidbhmgdt3ajzgoeywwxdbdcquone7buyenwhirl6af2z3gmftiys4 | RawLeaf   |       /Flibbertigibbet5/eorþscyld.pdf [1024576:1280719] (256,144 B)
+bafkreib6iawulrjvzet7dxbqdqneqa7kpy2kacvq7fawjvmlgveoakuzzy | RawLeaf   |       /Flibbertigibbet5/eorþscyld.pdf [1280720:1536863] (256,144 B)
+bafkreicbbl7whtfqsoz6tu663qicdisdyvzp4pp4ylggcttc44j63bdhxy | RawLeaf   |       /Flibbertigibbet5/eorþscyld.pdf [1536864:1793007] (256,144 B)
+bafkreifxe2irzoxtzk3ltpunioehodovu4pwzdtjr2lqtmkg7hyh3o5r2e | RawLeaf   |       /Flibbertigibbet5/eorþscyld.pdf [1793008:2049151] (256,144 B)
+bafkreihr2m4zfx4qvpwkp2fnihn7gbjq6gyr2gv5nbibt2nuajnp2k6pvq | RawLeaf   |       /Flibbertigibbet5/eorþscyld.pdf [2049152:2305295] (256,144 B)
+bafkreibhyumtv62kh3d4rvwpxkdlr52uur5thgmbtyuyxas3c424od7cta | RawLeaf   |       /Flibbertigibbet5/eorþscyld.pdf [2305296:2561439] (256,144 B)
+bafkreiatyvemaol2uxceo4suktpmusl53dqgg5bcqi2rkfhlxnnvpigkci | RawLeaf   |       /Flibbertigibbet5/eorþscyld.pdf [2561440:2817583] (256,144 B)
+bafkreias6ygzx2pnowi3hxj5kmed2rm74hgigwijiandz7vamvrohtkpje | RawLeaf   |       /Flibbertigibbet5/eorþscyld.pdf [2817584:3073727] (256,144 B)
+bafkreihf5g2wmsblx67664w2k3m7hj2bg2wnpumlnty7ssw4gj46oj3bxa | RawLeaf   |       /Flibbertigibbet5/eorþscyld.pdf [3073728:3329871] (256,144 B)
+bafkreib7gr6yi6lhl2p5izuxrxpknf5tc5lhkf5tdhzaxw5g66jxqichra | RawLeaf   |       /Flibbertigibbet5/eorþscyld.pdf [3329872:3586015] (256,144 B)
+bafkreigmnnfehab7c4tblwqgydbaoc76y34rkjfetayb6ytql2eywqnq5y | RawLeaf   |       /Flibbertigibbet5/eorþscyld.pdf [3586016:3842159] (256,144 B)
+bafkreiax5uhfktinmfo3ovm7geaf2266u5ya2slq4bob6eeginffbewszu | RawLeaf   |       /Flibbertigibbet5/eorþscyld.pdf [3842160:4098303] (256,144 B)
+bafkreic5chuwrtofd6ymxawcaxulacfewzfi3zroakmkwjkfmadrxrmln4 | RawLeaf   |       /Flibbertigibbet5/eorþscyld.pdf [4098304:4354447] (256,144 B)
+bafkreich7pcb4lnheypmqb4sikk5m6cuqqbxbjzuk767cx47djxac45o64 | RawLeaf   |       /Flibbertigibbet5/eorþscyld.pdf [4354448:4558477] (204,030 B)
 ```
 
 #### entity
@@ -215,25 +215,25 @@ bafkreich7pcb4lnheypmqb4sikk5m6cuqqbxbjzuk767cx47djxac45o64 | RawLeaf   |       
 ```
 bafybeifrrglx2issn2had5rtstn3xltla6vxmpjfwfz7o3hapvkynh4zoq | Directory | /
 bafybeicqlqnzd2tvs5vlo4c2dz72ryvouwmjwpu2mvxrocuj2u26joxeam | Directory | ↳ /Flibbertigibbet5
-bafybeigutoywu5bj3hlcdr4mkm6yepqnwvq5xodulrz2wstwteko2266te | File      |   ↳ /eorþscyld.pdf[0:4558477] (4558478 B)
-bafkreidz265issniggrhdjbwp3c5o4fnmg7xsa6hbn3kmyo7bsafc3jjsy | RawLeaf   |     ↳ /eorþscyld.pdf[0:256143] (256144 B)
-bafkreiepissrnjsgcanpe6hzen5kv66glcr5x5vw5vhferkjscxdj2uv3y | RawLeaf   |       /eorþscyld.pdf[256144:512287] (256144 B)
-bafkreifohr4rlzjpskbdcntrjzolglq6e5uf7n4mgdiw7wl2yhovhx46ve | RawLeaf   |       /eorþscyld.pdf[512288:768431] (256144 B)
-bafkreihiulihaonenbbtrbptmcmzcg2hvk6dypdxvmposz7ansd6h5mkla | RawLeaf   |       /eorþscyld.pdf[768432:1024575] (256144 B)
-bafkreidbhmgdt3ajzgoeywwxdbdcquone7buyenwhirl6af2z3gmftiys4 | RawLeaf   |       /eorþscyld.pdf[1024576:1280719] (256144 B)
-bafkreib6iawulrjvzet7dxbqdqneqa7kpy2kacvq7fawjvmlgveoakuzzy | RawLeaf   |       /eorþscyld.pdf[1280720:1536863] (256144 B)
-bafkreicbbl7whtfqsoz6tu663qicdisdyvzp4pp4ylggcttc44j63bdhxy | RawLeaf   |       /eorþscyld.pdf[1536864:1793007] (256144 B)
-bafkreifxe2irzoxtzk3ltpunioehodovu4pwzdtjr2lqtmkg7hyh3o5r2e | RawLeaf   |       /eorþscyld.pdf[1793008:2049151] (256144 B)
-bafkreihr2m4zfx4qvpwkp2fnihn7gbjq6gyr2gv5nbibt2nuajnp2k6pvq | RawLeaf   |       /eorþscyld.pdf[2049152:2305295] (256144 B)
-bafkreibhyumtv62kh3d4rvwpxkdlr52uur5thgmbtyuyxas3c424od7cta | RawLeaf   |       /eorþscyld.pdf[2305296:2561439] (256144 B)
-bafkreiatyvemaol2uxceo4suktpmusl53dqgg5bcqi2rkfhlxnnvpigkci | RawLeaf   |       /eorþscyld.pdf[2561440:2817583] (256144 B)
-bafkreias6ygzx2pnowi3hxj5kmed2rm74hgigwijiandz7vamvrohtkpje | RawLeaf   |       /eorþscyld.pdf[2817584:3073727] (256144 B)
-bafkreihf5g2wmsblx67664w2k3m7hj2bg2wnpumlnty7ssw4gj46oj3bxa | RawLeaf   |       /eorþscyld.pdf[3073728:3329871] (256144 B)
-bafkreib7gr6yi6lhl2p5izuxrxpknf5tc5lhkf5tdhzaxw5g66jxqichra | RawLeaf   |       /eorþscyld.pdf[3329872:3586015] (256144 B)
-bafkreigmnnfehab7c4tblwqgydbaoc76y34rkjfetayb6ytql2eywqnq5y | RawLeaf   |       /eorþscyld.pdf[3586016:3842159] (256144 B)
-bafkreiax5uhfktinmfo3ovm7geaf2266u5ya2slq4bob6eeginffbewszu | RawLeaf   |       /eorþscyld.pdf[3842160:4098303] (256144 B)
-bafkreic5chuwrtofd6ymxawcaxulacfewzfi3zroakmkwjkfmadrxrmln4 | RawLeaf   |       /eorþscyld.pdf[4098304:4354447] (256144 B)
-bafkreich7pcb4lnheypmqb4sikk5m6cuqqbxbjzuk767cx47djxac45o64 | RawLeaf   |       /eorþscyld.pdf[4354448:4558477] (204030 B)
+bafybeigutoywu5bj3hlcdr4mkm6yepqnwvq5xodulrz2wstwteko2266te | File      |   ↳ /Flibbertigibbet5/eorþscyld.pdf [0:4558477] (4,558,478 B)
+bafkreidz265issniggrhdjbwp3c5o4fnmg7xsa6hbn3kmyo7bsafc3jjsy | RawLeaf   |     ↳ /Flibbertigibbet5/eorþscyld.pdf [0:256143] (256,144 B)
+bafkreiepissrnjsgcanpe6hzen5kv66glcr5x5vw5vhferkjscxdj2uv3y | RawLeaf   |       /Flibbertigibbet5/eorþscyld.pdf [256144:512287] (256,144 B)
+bafkreifohr4rlzjpskbdcntrjzolglq6e5uf7n4mgdiw7wl2yhovhx46ve | RawLeaf   |       /Flibbertigibbet5/eorþscyld.pdf [512288:768431] (256,144 B)
+bafkreihiulihaonenbbtrbptmcmzcg2hvk6dypdxvmposz7ansd6h5mkla | RawLeaf   |       /Flibbertigibbet5/eorþscyld.pdf [768432:1024575] (256,144 B)
+bafkreidbhmgdt3ajzgoeywwxdbdcquone7buyenwhirl6af2z3gmftiys4 | RawLeaf   |       /Flibbertigibbet5/eorþscyld.pdf [1024576:1280719] (256,144 B)
+bafkreib6iawulrjvzet7dxbqdqneqa7kpy2kacvq7fawjvmlgveoakuzzy | RawLeaf   |       /Flibbertigibbet5/eorþscyld.pdf [1280720:1536863] (256,144 B)
+bafkreicbbl7whtfqsoz6tu663qicdisdyvzp4pp4ylggcttc44j63bdhxy | RawLeaf   |       /Flibbertigibbet5/eorþscyld.pdf [1536864:1793007] (256,144 B)
+bafkreifxe2irzoxtzk3ltpunioehodovu4pwzdtjr2lqtmkg7hyh3o5r2e | RawLeaf   |       /Flibbertigibbet5/eorþscyld.pdf [1793008:2049151] (256,144 B)
+bafkreihr2m4zfx4qvpwkp2fnihn7gbjq6gyr2gv5nbibt2nuajnp2k6pvq | RawLeaf   |       /Flibbertigibbet5/eorþscyld.pdf [2049152:2305295] (256,144 B)
+bafkreibhyumtv62kh3d4rvwpxkdlr52uur5thgmbtyuyxas3c424od7cta | RawLeaf   |       /Flibbertigibbet5/eorþscyld.pdf [2305296:2561439] (256,144 B)
+bafkreiatyvemaol2uxceo4suktpmusl53dqgg5bcqi2rkfhlxnnvpigkci | RawLeaf   |       /Flibbertigibbet5/eorþscyld.pdf [2561440:2817583] (256,144 B)
+bafkreias6ygzx2pnowi3hxj5kmed2rm74hgigwijiandz7vamvrohtkpje | RawLeaf   |       /Flibbertigibbet5/eorþscyld.pdf [2817584:3073727] (256,144 B)
+bafkreihf5g2wmsblx67664w2k3m7hj2bg2wnpumlnty7ssw4gj46oj3bxa | RawLeaf   |       /Flibbertigibbet5/eorþscyld.pdf [3073728:3329871] (256,144 B)
+bafkreib7gr6yi6lhl2p5izuxrxpknf5tc5lhkf5tdhzaxw5g66jxqichra | RawLeaf   |       /Flibbertigibbet5/eorþscyld.pdf [3329872:3586015] (256,144 B)
+bafkreigmnnfehab7c4tblwqgydbaoc76y34rkjfetayb6ytql2eywqnq5y | RawLeaf   |       /Flibbertigibbet5/eorþscyld.pdf [3586016:3842159] (256,144 B)
+bafkreiax5uhfktinmfo3ovm7geaf2266u5ya2slq4bob6eeginffbewszu | RawLeaf   |       /Flibbertigibbet5/eorþscyld.pdf [3842160:4098303] (256,144 B)
+bafkreic5chuwrtofd6ymxawcaxulacfewzfi3zroakmkwjkfmadrxrmln4 | RawLeaf   |       /Flibbertigibbet5/eorþscyld.pdf [4098304:4354447] (256,144 B)
+bafkreich7pcb4lnheypmqb4sikk5m6cuqqbxbjzuk767cx47djxac45o64 | RawLeaf   |       /Flibbertigibbet5/eorþscyld.pdf [4354448:4558477] (204,030 B)
 ```
 
 #### block
@@ -247,7 +247,7 @@ bafkreich7pcb4lnheypmqb4sikk5m6cuqqbxbjzuk767cx47djxac45o64 | RawLeaf   |       
 ```
 bafybeifrrglx2issn2had5rtstn3xltla6vxmpjfwfz7o3hapvkynh4zoq | Directory | /
 bafybeicqlqnzd2tvs5vlo4c2dz72ryvouwmjwpu2mvxrocuj2u26joxeam | Directory | ↳ /Flibbertigibbet5
-bafybeigutoywu5bj3hlcdr4mkm6yepqnwvq5xodulrz2wstwteko2266te | File      |   ↳ /eorþscyld.pdf[0:4558477] (4558478 B)
+bafybeigutoywu5bj3hlcdr4mkm6yepqnwvq5xodulrz2wstwteko2266te | File      |   ↳ /Flibbertigibbet5/eorþscyld.pdf [0:4558477] (4,558,478 B)
 ```
 
 ### Sharded file in hamt in directory
@@ -265,20 +265,20 @@ Same as the previous case, but with the nested directory replaced by a multi-blo
 ```
 bafybeifrrglx2issn2had5rtstn3xltla6vxmpjfwfz7o3hapvkynh4zoq | Directory | /
 bafybeiahh6giyfzxpsp6b4y6j6r34xjgsb2si7n6dszwoevnjxdcuee5yq | HAMTShard | ↳ /O
-bafybeics7ohtet4wfuzszfchbttrgotqzpuruq4bencpdtc443vawbcbni | HAMTShard |   ↳ <hamt>
-bafybeigqgljdsq72owvi3mtgjwkrfmmjpevzbya6pu52ufj55h5ypznpx4 | File      |     ↳ /Othello.png[0:2977730] (2977731 B)
-bafkreibyblakon7atsv2hwzyzrweeb5uriksuscfxjtlzj3l56xmrouwke | RawLeaf   |       ↳ /Othello.png[0:256143] (256144 B)
-bafkreic7nx6e7zezkdz5lp2xcwarmgavr62cyrmtepyagvm2ivuo3jesqe | RawLeaf   |         /Othello.png[256144:512287] (256144 B)
-bafkreicylwcsi7ovreggex5yc7jolt5zrwf74ida3sprzsw37oxpzkwvte | RawLeaf   |         /Othello.png[512288:768431] (256144 B)
-bafkreiainpsn6gadltlhqzgakxvdbxrz5n2cstizn3afhsr2nwefus7pqm | RawLeaf   |         /Othello.png[768432:1024575] (256144 B)
-bafkreihuwjz4av7scz3fdjejtrx3k6ycdjudjusuz6sjzbbsewpgslosxi | RawLeaf   |         /Othello.png[1024576:1280719] (256144 B)
-bafkreiexmzld3vi72v665bbqn473mfc5smmtd6nnndl7dzcapzlxdwzhq4 | RawLeaf   |         /Othello.png[1280720:1536863] (256144 B)
-bafkreignp6prdhvi4mxoef5ybl4c644eyeikd42w3z2atw5mgbzw5p4374 | RawLeaf   |         /Othello.png[1536864:1793007] (256144 B)
-bafkreia6nxplcal74ycukjwfmwmaaraeg6qwclfvb6qja2iaayukzsedoa | RawLeaf   |         /Othello.png[1793008:2049151] (256144 B)
-bafkreiae6iay4fqiethqcvva4qazdxb7szb4dh77dsxiskvewhm5sepwfm | RawLeaf   |         /Othello.png[2049152:2305295] (256144 B)
-bafkreieprkc6i3qzg47k5y3zxejsoglyl5fwrk3fnslbmdmau7surwiocy | RawLeaf   |         /Othello.png[2305296:2561439] (256144 B)
-bafkreidwsenghahefqcfw5ikxd6osi6a35koyki4gibw3sunlmqrroqzc4 | RawLeaf   |         /Othello.png[2561440:2817583] (256144 B)
-bafkreicn24jr4rwjcptuzu677u2aeqyirf7weradcafcnkq5hzo7wickkq | RawLeaf   |         /Othello.png[2817584:2977730] (160147 B)
+bafybeics7ohtet4wfuzszfchbttrgotqzpuruq4bencpdtc443vawbcbni | HAMTShard |   ↳ /O [A]
+bafybeigqgljdsq72owvi3mtgjwkrfmmjpevzbya6pu52ufj55h5ypznpx4 | File      |     ↳ /O/Othello.png [0:2977730] (2,977,731 B)
+bafkreibyblakon7atsv2hwzyzrweeb5uriksuscfxjtlzj3l56xmrouwke | RawLeaf   |       ↳ /O/Othello.png [0:256143] (256,144 B)
+bafkreic7nx6e7zezkdz5lp2xcwarmgavr62cyrmtepyagvm2ivuo3jesqe | RawLeaf   |         /O/Othello.png [256144:512287] (256,144 B)
+bafkreicylwcsi7ovreggex5yc7jolt5zrwf74ida3sprzsw37oxpzkwvte | RawLeaf   |         /O/Othello.png [512288:768431] (256,144 B)
+bafkreiainpsn6gadltlhqzgakxvdbxrz5n2cstizn3afhsr2nwefus7pqm | RawLeaf   |         /O/Othello.png [768432:1024575] (256,144 B)
+bafkreihuwjz4av7scz3fdjejtrx3k6ycdjudjusuz6sjzbbsewpgslosxi | RawLeaf   |         /O/Othello.png [1024576:1280719] (256,144 B)
+bafkreiexmzld3vi72v665bbqn473mfc5smmtd6nnndl7dzcapzlxdwzhq4 | RawLeaf   |         /O/Othello.png [1280720:1536863] (256,144 B)
+bafkreignp6prdhvi4mxoef5ybl4c644eyeikd42w3z2atw5mgbzw5p4374 | RawLeaf   |         /O/Othello.png [1536864:1793007] (256,144 B)
+bafkreia6nxplcal74ycukjwfmwmaaraeg6qwclfvb6qja2iaayukzsedoa | RawLeaf   |         /O/Othello.png [1793008:2049151] (256,144 B)
+bafkreiae6iay4fqiethqcvva4qazdxb7szb4dh77dsxiskvewhm5sepwfm | RawLeaf   |         /O/Othello.png [2049152:2305295] (256,144 B)
+bafkreieprkc6i3qzg47k5y3zxejsoglyl5fwrk3fnslbmdmau7surwiocy | RawLeaf   |         /O/Othello.png [2305296:2561439] (256,144 B)
+bafkreidwsenghahefqcfw5ikxd6osi6a35koyki4gibw3sunlmqrroqzc4 | RawLeaf   |         /O/Othello.png [2561440:2817583] (256,144 B)
+bafkreicn24jr4rwjcptuzu677u2aeqyirf7weradcafcnkq5hzo7wickkq | RawLeaf   |         /O/Othello.png [2817584:2977730] (160,147 B)
 ```
 
 #### entity
@@ -292,20 +292,20 @@ bafkreicn24jr4rwjcptuzu677u2aeqyirf7weradcafcnkq5hzo7wickkq | RawLeaf   |       
 ```
 bafybeifrrglx2issn2had5rtstn3xltla6vxmpjfwfz7o3hapvkynh4zoq | Directory | /
 bafybeiahh6giyfzxpsp6b4y6j6r34xjgsb2si7n6dszwoevnjxdcuee5yq | HAMTShard | ↳ /O
-bafybeics7ohtet4wfuzszfchbttrgotqzpuruq4bencpdtc443vawbcbni | HAMTShard |   ↳ <hamt>
-bafybeigqgljdsq72owvi3mtgjwkrfmmjpevzbya6pu52ufj55h5ypznpx4 | File      |     ↳ /Othello.png[0:2977730] (2977731 B)
-bafkreibyblakon7atsv2hwzyzrweeb5uriksuscfxjtlzj3l56xmrouwke | RawLeaf   |       ↳ /Othello.png[0:256143] (256144 B)
-bafkreic7nx6e7zezkdz5lp2xcwarmgavr62cyrmtepyagvm2ivuo3jesqe | RawLeaf   |         /Othello.png[256144:512287] (256144 B)
-bafkreicylwcsi7ovreggex5yc7jolt5zrwf74ida3sprzsw37oxpzkwvte | RawLeaf   |         /Othello.png[512288:768431] (256144 B)
-bafkreiainpsn6gadltlhqzgakxvdbxrz5n2cstizn3afhsr2nwefus7pqm | RawLeaf   |         /Othello.png[768432:1024575] (256144 B)
-bafkreihuwjz4av7scz3fdjejtrx3k6ycdjudjusuz6sjzbbsewpgslosxi | RawLeaf   |         /Othello.png[1024576:1280719] (256144 B)
-bafkreiexmzld3vi72v665bbqn473mfc5smmtd6nnndl7dzcapzlxdwzhq4 | RawLeaf   |         /Othello.png[1280720:1536863] (256144 B)
-bafkreignp6prdhvi4mxoef5ybl4c644eyeikd42w3z2atw5mgbzw5p4374 | RawLeaf   |         /Othello.png[1536864:1793007] (256144 B)
-bafkreia6nxplcal74ycukjwfmwmaaraeg6qwclfvb6qja2iaayukzsedoa | RawLeaf   |         /Othello.png[1793008:2049151] (256144 B)
-bafkreiae6iay4fqiethqcvva4qazdxb7szb4dh77dsxiskvewhm5sepwfm | RawLeaf   |         /Othello.png[2049152:2305295] (256144 B)
-bafkreieprkc6i3qzg47k5y3zxejsoglyl5fwrk3fnslbmdmau7surwiocy | RawLeaf   |         /Othello.png[2305296:2561439] (256144 B)
-bafkreidwsenghahefqcfw5ikxd6osi6a35koyki4gibw3sunlmqrroqzc4 | RawLeaf   |         /Othello.png[2561440:2817583] (256144 B)
-bafkreicn24jr4rwjcptuzu677u2aeqyirf7weradcafcnkq5hzo7wickkq | RawLeaf   |         /Othello.png[2817584:2977730] (160147 B)
+bafybeics7ohtet4wfuzszfchbttrgotqzpuruq4bencpdtc443vawbcbni | HAMTShard |   ↳ /O [A]
+bafybeigqgljdsq72owvi3mtgjwkrfmmjpevzbya6pu52ufj55h5ypznpx4 | File      |     ↳ /O/Othello.png [0:2977730] (2,977,731 B)
+bafkreibyblakon7atsv2hwzyzrweeb5uriksuscfxjtlzj3l56xmrouwke | RawLeaf   |       ↳ /O/Othello.png [0:256143] (256,144 B)
+bafkreic7nx6e7zezkdz5lp2xcwarmgavr62cyrmtepyagvm2ivuo3jesqe | RawLeaf   |         /O/Othello.png [256144:512287] (256,144 B)
+bafkreicylwcsi7ovreggex5yc7jolt5zrwf74ida3sprzsw37oxpzkwvte | RawLeaf   |         /O/Othello.png [512288:768431] (256,144 B)
+bafkreiainpsn6gadltlhqzgakxvdbxrz5n2cstizn3afhsr2nwefus7pqm | RawLeaf   |         /O/Othello.png [768432:1024575] (256,144 B)
+bafkreihuwjz4av7scz3fdjejtrx3k6ycdjudjusuz6sjzbbsewpgslosxi | RawLeaf   |         /O/Othello.png [1024576:1280719] (256,144 B)
+bafkreiexmzld3vi72v665bbqn473mfc5smmtd6nnndl7dzcapzlxdwzhq4 | RawLeaf   |         /O/Othello.png [1280720:1536863] (256,144 B)
+bafkreignp6prdhvi4mxoef5ybl4c644eyeikd42w3z2atw5mgbzw5p4374 | RawLeaf   |         /O/Othello.png [1536864:1793007] (256,144 B)
+bafkreia6nxplcal74ycukjwfmwmaaraeg6qwclfvb6qja2iaayukzsedoa | RawLeaf   |         /O/Othello.png [1793008:2049151] (256,144 B)
+bafkreiae6iay4fqiethqcvva4qazdxb7szb4dh77dsxiskvewhm5sepwfm | RawLeaf   |         /O/Othello.png [2049152:2305295] (256,144 B)
+bafkreieprkc6i3qzg47k5y3zxejsoglyl5fwrk3fnslbmdmau7surwiocy | RawLeaf   |         /O/Othello.png [2305296:2561439] (256,144 B)
+bafkreidwsenghahefqcfw5ikxd6osi6a35koyki4gibw3sunlmqrroqzc4 | RawLeaf   |         /O/Othello.png [2561440:2817583] (256,144 B)
+bafkreicn24jr4rwjcptuzu677u2aeqyirf7weradcafcnkq5hzo7wickkq | RawLeaf   |         /O/Othello.png [2817584:2977730] (160,147 B)
 ```
 
 #### block
@@ -319,8 +319,8 @@ bafkreicn24jr4rwjcptuzu677u2aeqyirf7weradcafcnkq5hzo7wickkq | RawLeaf   |       
 ```
 bafybeifrrglx2issn2had5rtstn3xltla6vxmpjfwfz7o3hapvkynh4zoq | Directory | /
 bafybeiahh6giyfzxpsp6b4y6j6r34xjgsb2si7n6dszwoevnjxdcuee5yq | HAMTShard | ↳ /O
-bafybeics7ohtet4wfuzszfchbttrgotqzpuruq4bencpdtc443vawbcbni | HAMTShard |   ↳ <hamt>
-bafybeigqgljdsq72owvi3mtgjwkrfmmjpevzbya6pu52ufj55h5ypznpx4 | File      |     ↳ /Othello.png[0:2977730] (2977731 B)
+bafybeics7ohtet4wfuzszfchbttrgotqzpuruq4bencpdtc443vawbcbni | HAMTShard |   ↳ /O [A]
+bafybeigqgljdsq72owvi3mtgjwkrfmmjpevzbya6pu52ufj55h5ypznpx4 | File      |     ↳ /O/Othello.png [0:2977730] (2,977,731 B)
 ```
 
 ### Sharded file in directory in hamt in directory
@@ -338,12 +338,12 @@ Same as the previous case but with an additional single-block directory inside t
 ```
 bafybeifrrglx2issn2had5rtstn3xltla6vxmpjfwfz7o3hapvkynh4zoq | Directory | /
 bafybeie3mbyp7k77vrpiduaifyhdeqvusjn7qofzwtsp47yavyyb62z32y | HAMTShard | ↳ /Zigzagumptious
-bafybeied5si546vcp6klpngu77kftitzffdlxk5ajaytadc3p3ptr7tvam | HAMTShard |   ↳ <hamt>
-bafybeifjkcls323ddq3t5ov22yl7i6ks36a7jzv33pjy4stqkils6jzvqe | Directory |     ↳ /Throttlebottom
-bafybeify427noacqiu6sxaaunk5uw2xhelnkcwktkvh6woi6ahlipsz7em | File      |       ↳ /supercalifragilisticexpialidocious.txt[0:568520] (568521 B)
-bafkreicdwgfhxwnzq7i34cuhnqqqxz6d6jtirupjy5kq3uaphopyw5e2ky | RawLeaf   |         ↳ /supercalifragilisticexpialidocious.txt[0:256143] (256144 B)
-bafkreifmk6qfl6ucap7btfu35rjd37bh7uuefavq6nsuungxjl3or7bz2e | RawLeaf   |           /supercalifragilisticexpialidocious.txt[256144:512287] (256144 B)
-bafkreifk2vcldftxe57ml2cxyfcwb34ukkhaopm46kv3as5vo26ht63fci | RawLeaf   |           /supercalifragilisticexpialidocious.txt[512288:568520] (56233 B)
+bafybeied5si546vcp6klpngu77kftitzffdlxk5ajaytadc3p3ptr7tvam | HAMTShard |   ↳ /Zigzagumptious [9]
+bafybeifjkcls323ddq3t5ov22yl7i6ks36a7jzv33pjy4stqkils6jzvqe | Directory |     ↳ /Zigzagumptious/Throttlebottom
+bafybeify427noacqiu6sxaaunk5uw2xhelnkcwktkvh6woi6ahlipsz7em | File      |       ↳ /Zigzagumptious/Throttlebottom/supercalifragilisticexpialidocious.txt [0:568520] (568,521 B)
+bafkreicdwgfhxwnzq7i34cuhnqqqxz6d6jtirupjy5kq3uaphopyw5e2ky | RawLeaf   |         ↳ /Zigzagumptious/Throttlebottom/supercalifragilisticexpialidocious.txt [0:256143] (256,144 B)
+bafkreifmk6qfl6ucap7btfu35rjd37bh7uuefavq6nsuungxjl3or7bz2e | RawLeaf   |           /Zigzagumptious/Throttlebottom/supercalifragilisticexpialidocious.txt [256144:512287] (256,144 B)
+bafkreifk2vcldftxe57ml2cxyfcwb34ukkhaopm46kv3as5vo26ht63fci | RawLeaf   |           /Zigzagumptious/Throttlebottom/supercalifragilisticexpialidocious.txt [512288:568520] (56,233 B)
 ```
 
 #### entity
@@ -357,8 +357,8 @@ bafkreifk2vcldftxe57ml2cxyfcwb34ukkhaopm46kv3as5vo26ht63fci | RawLeaf   |       
 ```
 bafybeifrrglx2issn2had5rtstn3xltla6vxmpjfwfz7o3hapvkynh4zoq | Directory | /
 bafybeie3mbyp7k77vrpiduaifyhdeqvusjn7qofzwtsp47yavyyb62z32y | HAMTShard | ↳ /Zigzagumptious
-bafybeied5si546vcp6klpngu77kftitzffdlxk5ajaytadc3p3ptr7tvam | HAMTShard |   ↳ <hamt>
-bafybeifjkcls323ddq3t5ov22yl7i6ks36a7jzv33pjy4stqkils6jzvqe | Directory |     ↳ /Throttlebottom
+bafybeied5si546vcp6klpngu77kftitzffdlxk5ajaytadc3p3ptr7tvam | HAMTShard |   ↳ /Zigzagumptious [9]
+bafybeifjkcls323ddq3t5ov22yl7i6ks36a7jzv33pjy4stqkils6jzvqe | Directory |     ↳ /Zigzagumptious/Throttlebottom
 ```
 
 #### block
@@ -372,8 +372,8 @@ bafybeifjkcls323ddq3t5ov22yl7i6ks36a7jzv33pjy4stqkils6jzvqe | Directory |     �
 ```
 bafybeifrrglx2issn2had5rtstn3xltla6vxmpjfwfz7o3hapvkynh4zoq | Directory | /
 bafybeie3mbyp7k77vrpiduaifyhdeqvusjn7qofzwtsp47yavyyb62z32y | HAMTShard | ↳ /Zigzagumptious
-bafybeied5si546vcp6klpngu77kftitzffdlxk5ajaytadc3p3ptr7tvam | HAMTShard |   ↳ <hamt>
-bafybeifjkcls323ddq3t5ov22yl7i6ks36a7jzv33pjy4stqkils6jzvqe | Directory |     ↳ /Throttlebottom
+bafybeied5si546vcp6klpngu77kftitzffdlxk5ajaytadc3p3ptr7tvam | HAMTShard |   ↳ /Zigzagumptious [9]
+bafybeifjkcls323ddq3t5ov22yl7i6ks36a7jzv33pjy4stqkils6jzvqe | Directory |     ↳ /Zigzagumptious/Throttlebottom
 ```
 
 ### Small file in a directory in a hamt in a directory
@@ -391,10 +391,10 @@ Same as "Small file in a directory in directory in directory" but with a multi-b
 ```
 bafybeifrrglx2issn2had5rtstn3xltla6vxmpjfwfz7o3hapvkynh4zoq | Directory | /
 bafybeie3mbyp7k77vrpiduaifyhdeqvusjn7qofzwtsp47yavyyb62z32y | HAMTShard | ↳ /Zigzagumptious
-bafybeiggzqpxmfbve7sutrmcwrlwpx4tkno536d7qdgd6hnhxf74t7gzee | HAMTShard |   ↳ <hamt>
-bafybeigfwz54atwgnklb72rfqqn2a3ywoontgf3b3kekxwoxalptx7gc3e | HAMTShard |     ↳ <hamt>
-bafybeid25clhrmlypqcsl4ehgxczbidzu2sqvrtuoeckh32hmzz7qisk6m | Directory |       ↳ /fyrd
-bafkreigtatgpa6dpkm2vxaeglfz4t3j2kkcan6jjxdf4ytwehspjbpxe54 | RawLeaf   |         ↳ /Cordelia.docx[0:329] (330 B)
+bafybeiggzqpxmfbve7sutrmcwrlwpx4tkno536d7qdgd6hnhxf74t7gzee | HAMTShard |   ↳ /Zigzagumptious [0]
+bafybeigfwz54atwgnklb72rfqqn2a3ywoontgf3b3kekxwoxalptx7gc3e | HAMTShard |     ↳ /Zigzagumptious [0]
+bafybeid25clhrmlypqcsl4ehgxczbidzu2sqvrtuoeckh32hmzz7qisk6m | Directory |       ↳ /Zigzagumptious/fyrd
+bafkreigtatgpa6dpkm2vxaeglfz4t3j2kkcan6jjxdf4ytwehspjbpxe54 | RawLeaf   |         ↳ /Zigzagumptious/fyrd/Cordelia.docx [0:329] (330 B)
 ```
 
 #### entity
@@ -408,10 +408,10 @@ bafkreigtatgpa6dpkm2vxaeglfz4t3j2kkcan6jjxdf4ytwehspjbpxe54 | RawLeaf   |       
 ```
 bafybeifrrglx2issn2had5rtstn3xltla6vxmpjfwfz7o3hapvkynh4zoq | Directory | /
 bafybeie3mbyp7k77vrpiduaifyhdeqvusjn7qofzwtsp47yavyyb62z32y | HAMTShard | ↳ /Zigzagumptious
-bafybeiggzqpxmfbve7sutrmcwrlwpx4tkno536d7qdgd6hnhxf74t7gzee | HAMTShard |   ↳ <hamt>
-bafybeigfwz54atwgnklb72rfqqn2a3ywoontgf3b3kekxwoxalptx7gc3e | HAMTShard |     ↳ <hamt>
-bafybeid25clhrmlypqcsl4ehgxczbidzu2sqvrtuoeckh32hmzz7qisk6m | Directory |       ↳ /fyrd
-bafkreigtatgpa6dpkm2vxaeglfz4t3j2kkcan6jjxdf4ytwehspjbpxe54 | RawLeaf   |         ↳ /Cordelia.docx[0:329] (330 B)
+bafybeiggzqpxmfbve7sutrmcwrlwpx4tkno536d7qdgd6hnhxf74t7gzee | HAMTShard |   ↳ /Zigzagumptious [0]
+bafybeigfwz54atwgnklb72rfqqn2a3ywoontgf3b3kekxwoxalptx7gc3e | HAMTShard |     ↳ /Zigzagumptious [0]
+bafybeid25clhrmlypqcsl4ehgxczbidzu2sqvrtuoeckh32hmzz7qisk6m | Directory |       ↳ /Zigzagumptious/fyrd
+bafkreigtatgpa6dpkm2vxaeglfz4t3j2kkcan6jjxdf4ytwehspjbpxe54 | RawLeaf   |         ↳ /Zigzagumptious/fyrd/Cordelia.docx [0:329] (330 B)
 ```
 
 #### block
@@ -425,10 +425,10 @@ bafkreigtatgpa6dpkm2vxaeglfz4t3j2kkcan6jjxdf4ytwehspjbpxe54 | RawLeaf   |       
 ```
 bafybeifrrglx2issn2had5rtstn3xltla6vxmpjfwfz7o3hapvkynh4zoq | Directory | /
 bafybeie3mbyp7k77vrpiduaifyhdeqvusjn7qofzwtsp47yavyyb62z32y | HAMTShard | ↳ /Zigzagumptious
-bafybeiggzqpxmfbve7sutrmcwrlwpx4tkno536d7qdgd6hnhxf74t7gzee | HAMTShard |   ↳ <hamt>
-bafybeigfwz54atwgnklb72rfqqn2a3ywoontgf3b3kekxwoxalptx7gc3e | HAMTShard |     ↳ <hamt>
-bafybeid25clhrmlypqcsl4ehgxczbidzu2sqvrtuoeckh32hmzz7qisk6m | Directory |       ↳ /fyrd
-bafkreigtatgpa6dpkm2vxaeglfz4t3j2kkcan6jjxdf4ytwehspjbpxe54 | RawLeaf   |         ↳ /Cordelia.docx[0:329] (330 B)
+bafybeiggzqpxmfbve7sutrmcwrlwpx4tkno536d7qdgd6hnhxf74t7gzee | HAMTShard |   ↳ /Zigzagumptious [0]
+bafybeigfwz54atwgnklb72rfqqn2a3ywoontgf3b3kekxwoxalptx7gc3e | HAMTShard |     ↳ /Zigzagumptious [0]
+bafybeid25clhrmlypqcsl4ehgxczbidzu2sqvrtuoeckh32hmzz7qisk6m | Directory |       ↳ /Zigzagumptious/fyrd
+bafkreigtatgpa6dpkm2vxaeglfz4t3j2kkcan6jjxdf4ytwehspjbpxe54 | RawLeaf   |         ↳ /Zigzagumptious/fyrd/Cordelia.docx [0:329] (330 B)
 ```
 
 ### Hamt in directory
@@ -446,22 +446,22 @@ A multi-block directory in the root of the UnixFS DAG as the target. The `all` s
 ```
 bafybeifrrglx2issn2had5rtstn3xltla6vxmpjfwfz7o3hapvkynh4zoq | Directory | /
 bafybeie3mbyp7k77vrpiduaifyhdeqvusjn7qofzwtsp47yavyyb62z32y | HAMTShard | ↳ /Zigzagumptious
-bafybeiggzqpxmfbve7sutrmcwrlwpx4tkno536d7qdgd6hnhxf74t7gzee | HAMTShard |   ↳ /Zigzagumptious
-bafybeigfwz54atwgnklb72rfqqn2a3ywoontgf3b3kekxwoxalptx7gc3e | HAMTShard |     ↳ /Zigzagumptious
-bafybeifr3w3eyq2oi6hxwbfoblor7s5pfvu3m4xyyzovxlk4g5xgslsqui | HAMTShard |     /Zigzagumptious
-bafybeigivdbrxmcixaqfap3rrs7ti5ycr7vj4xfbkjougq67k7ac5oz55a | HAMTShard |     /Zigzagumptious
-bafybeid3cny2p7fwt4znzm3wjncsesdk2rdze5fm5rzxjpbethy4657j6m | HAMTShard |     /Zigzagumptious
-bafybeidivwpxv37o6p4ton3xcpmg64pwk4zqlkuge7isafgsgjsvb6ce2u | HAMTShard |     /Zigzagumptious
-bafybeib5ptplpmtmoyif4lxt5erw5diivp6so4s57lvgfigs53d7zpc4uu | HAMTShard |     /Zigzagumptious
-bafybeiafmairlfkvgqgticndcs4uomkll4h5xotvnnsw2j7cx3rjwrbh7i | HAMTShard |     ↳ /Zigzagumptious
-bafybeifjo6xz3onvav6cnpjjuroa7vbzegoxgg5jn6smfvgfcpzwzdaipa | HAMTShard |     /Zigzagumptious
-bafybeied5si546vcp6klpngu77kftitzffdlxk5ajaytadc3p3ptr7tvam | HAMTShard |     /Zigzagumptious
-bafybeiar4b5hfriv2pmmbj7npemto6bev7sqkn4jpstwqtaudexpetpg4m | HAMTShard |     /Zigzagumptious
-bafybeifcekpohkm7qaczfwrrzcdz6j3ykwntawdnp7b7fjfech75vxpwf4 | HAMTShard |     ↳ /Zigzagumptious
-bafybeihnejxifhvlunhcswhghhrbues366h7o4xqp3ziyeicrdt5473za4 | HAMTShard |     /Zigzagumptious
-bafybeihlijmc2xyfmomw4fx53mlz3gpt6svgfu3vfokm4wmyd4dagfup24 | HAMTShard |     /Zigzagumptious
-bafybeihjbh7kptdfaoanrkzhdpx2jwjacg5ncdlcbbwqlum6vwqfga5fii | HAMTShard |     /Zigzagumptious
-bafybeidaz5aob6tdurpnuj2xeqsjkarqudtono6x2kgbzrzv46ugp3g4ju | HAMTShard |     /Zigzagumptious
+bafybeiggzqpxmfbve7sutrmcwrlwpx4tkno536d7qdgd6hnhxf74t7gzee | HAMTShard |   ↳ /Zigzagumptious [0]
+bafybeigfwz54atwgnklb72rfqqn2a3ywoontgf3b3kekxwoxalptx7gc3e | HAMTShard |     ↳ /Zigzagumptious [0]
+bafybeifr3w3eyq2oi6hxwbfoblor7s5pfvu3m4xyyzovxlk4g5xgslsqui | HAMTShard |     /Zigzagumptious [1]
+bafybeigivdbrxmcixaqfap3rrs7ti5ycr7vj4xfbkjougq67k7ac5oz55a | HAMTShard |     /Zigzagumptious [2]
+bafybeid3cny2p7fwt4znzm3wjncsesdk2rdze5fm5rzxjpbethy4657j6m | HAMTShard |     /Zigzagumptious [4]
+bafybeidivwpxv37o6p4ton3xcpmg64pwk4zqlkuge7isafgsgjsvb6ce2u | HAMTShard |     /Zigzagumptious [6]
+bafybeib5ptplpmtmoyif4lxt5erw5diivp6so4s57lvgfigs53d7zpc4uu | HAMTShard |     /Zigzagumptious [7]
+bafybeiafmairlfkvgqgticndcs4uomkll4h5xotvnnsw2j7cx3rjwrbh7i | HAMTShard |     ↳ /Zigzagumptious [F]
+bafybeifjo6xz3onvav6cnpjjuroa7vbzegoxgg5jn6smfvgfcpzwzdaipa | HAMTShard |     /Zigzagumptious [8]
+bafybeied5si546vcp6klpngu77kftitzffdlxk5ajaytadc3p3ptr7tvam | HAMTShard |     /Zigzagumptious [9]
+bafybeiar4b5hfriv2pmmbj7npemto6bev7sqkn4jpstwqtaudexpetpg4m | HAMTShard |     /Zigzagumptious [A]
+bafybeifcekpohkm7qaczfwrrzcdz6j3ykwntawdnp7b7fjfech75vxpwf4 | HAMTShard |     ↳ /Zigzagumptious [B]
+bafybeihnejxifhvlunhcswhghhrbues366h7o4xqp3ziyeicrdt5473za4 | HAMTShard |     /Zigzagumptious [C]
+bafybeihlijmc2xyfmomw4fx53mlz3gpt6svgfu3vfokm4wmyd4dagfup24 | HAMTShard |     /Zigzagumptious [D]
+bafybeihjbh7kptdfaoanrkzhdpx2jwjacg5ncdlcbbwqlum6vwqfga5fii | HAMTShard |     /Zigzagumptious [E]
+bafybeidaz5aob6tdurpnuj2xeqsjkarqudtono6x2kgbzrzv46ugp3g4ju | HAMTShard |     /Zigzagumptious [F]
 ```
 
 #### block
@@ -492,17 +492,17 @@ A single-block directory in the root of the UnixFS DAG as the target. `all` shou
 ```
 bafybeifrrglx2issn2had5rtstn3xltla6vxmpjfwfz7o3hapvkynh4zoq | Directory | /
 bafybeigdgcs3nulbgu6vtnyesfgsaau2grbxzbxxdtpgolsfhtrpjx6mw4 | Directory | ↳ /by
-bafybeicsa4ltuq6m3sxzzrkfy6wetemiqvbdgnitkjwlcduswh3cvsccxy | Directory |   ↳ /procrastinatorily
-bafkreiaquanb6uzch2bkv7iltvwipmawjfihb7jgejqww63vgbqshderxq | RawLeaf   |     ↳ * (/F[0:727] (728 B))
-bafkreigtze43gghvasxpp3o6mklllhilbyzs63kzdtdlzpyaznk44vxnye | RawLeaf   |       * (/Gallivant.png[0:1339] (1340 B))
-bafkreifrkcg75acl2yu4jv65x5u7yzn2cnpezmx432p2v2lryzhwqyp63u | RawLeaf   |       * (/Oberon.xml[0:512] (513 B))
-bafkreiac4vqpljai2qjxx7mgs2equqcs4oq6lmmie2oiqhrkmwukuez3cm | RawLeaf   |       * (/Pandemonium[0:917] (918 B))
-bafkreiclovx7khthefexgfku4n7pndbqthj5xuiv6ymbd3cx2bve3qebby | RawLeaf   |       * (/gūþweard.docx[0:580] (581 B))
-bafkreiaqchjvbofqnpwoxwrtcvelnz5neg4y5buqchwgnxwoigjofmnol4 | RawLeaf   |       * (/juxtapositionally.png[0:2426] (2427 B))
-bafkreif3y7x7uailqhjjuketaa2p34gidoj7ynmnmviejtynydov75dkbq | RawLeaf   |       * (/sǣlācend[0:430] (431 B))
-bafkreias4xj2qbg36tyo4wirl2db2x2emh4lbfpwq7t3dexjos236a5wgu | RawLeaf   |       * (/t.png[0:57] (58 B))
-bafkreidzryf2cxeo5bfkxulhxlgr6axh5qfrsh4ns6jwfd2yutzpkcoaxu | RawLeaf   |       * (/ya.xml[0:417] (418 B))
-bafkreihys4i2ow3csfrhefnmwruwte2bv5ik223ocgbvq3ckwj7xdxzc2m | RawLeaf   |       * (/ætheling.docx[0:81] (82 B))
+bafybeicsa4ltuq6m3sxzzrkfy6wetemiqvbdgnitkjwlcduswh3cvsccxy | Directory |   ↳ /by/procrastinatorily
+bafkreiaquanb6uzch2bkv7iltvwipmawjfihb7jgejqww63vgbqshderxq | RawLeaf   |     ↳ /by/procrastinatorily/F [0:727] (728 B)
+bafkreigtze43gghvasxpp3o6mklllhilbyzs63kzdtdlzpyaznk44vxnye | RawLeaf   |       /by/procrastinatorily/Gallivant.png [0:1339] (1,340 B)
+bafkreifrkcg75acl2yu4jv65x5u7yzn2cnpezmx432p2v2lryzhwqyp63u | RawLeaf   |       /by/procrastinatorily/Oberon.xml [0:512] (513 B)
+bafkreiac4vqpljai2qjxx7mgs2equqcs4oq6lmmie2oiqhrkmwukuez3cm | RawLeaf   |       /by/procrastinatorily/Pandemonium [0:917] (918 B)
+bafkreiclovx7khthefexgfku4n7pndbqthj5xuiv6ymbd3cx2bve3qebby | RawLeaf   |       /by/procrastinatorily/gūþweard.docx [0:580] (581 B)
+bafkreiaqchjvbofqnpwoxwrtcvelnz5neg4y5buqchwgnxwoigjofmnol4 | RawLeaf   |       /by/procrastinatorily/juxtapositionally.png [0:2426] (2,427 B)
+bafkreif3y7x7uailqhjjuketaa2p34gidoj7ynmnmviejtynydov75dkbq | RawLeaf   |       /by/procrastinatorily/sǣlācend [0:430] (431 B)
+bafkreias4xj2qbg36tyo4wirl2db2x2emh4lbfpwq7t3dexjos236a5wgu | RawLeaf   |       /by/procrastinatorily/t.png [0:57] (58 B)
+bafkreidzryf2cxeo5bfkxulhxlgr6axh5qfrsh4ns6jwfd2yutzpkcoaxu | RawLeaf   |       /by/procrastinatorily/ya.xml [0:417] (418 B)
+bafkreihys4i2ow3csfrhefnmwruwte2bv5ik223ocgbvq3ckwj7xdxzc2m | RawLeaf   |       /by/procrastinatorily/ætheling.docx [0:81] (82 B)
 ```
 
 #### entity
@@ -516,7 +516,7 @@ bafkreihys4i2ow3csfrhefnmwruwte2bv5ik223ocgbvq3ckwj7xdxzc2m | RawLeaf   |       
 ```
 bafybeifrrglx2issn2had5rtstn3xltla6vxmpjfwfz7o3hapvkynh4zoq | Directory | /
 bafybeigdgcs3nulbgu6vtnyesfgsaau2grbxzbxxdtpgolsfhtrpjx6mw4 | Directory | ↳ /by
-bafybeicsa4ltuq6m3sxzzrkfy6wetemiqvbdgnitkjwlcduswh3cvsccxy | Directory |   ↳ /procrastinatorily
+bafybeicsa4ltuq6m3sxzzrkfy6wetemiqvbdgnitkjwlcduswh3cvsccxy | Directory |   ↳ /by/procrastinatorily
 ```
 
 #### block
@@ -530,7 +530,7 @@ bafybeicsa4ltuq6m3sxzzrkfy6wetemiqvbdgnitkjwlcduswh3cvsccxy | Directory |   ↳ 
 ```
 bafybeifrrglx2issn2had5rtstn3xltla6vxmpjfwfz7o3hapvkynh4zoq | Directory | /
 bafybeigdgcs3nulbgu6vtnyesfgsaau2grbxzbxxdtpgolsfhtrpjx6mw4 | Directory | ↳ /by
-bafybeicsa4ltuq6m3sxzzrkfy6wetemiqvbdgnitkjwlcduswh3cvsccxy | Directory |   ↳ /procrastinatorily
+bafybeicsa4ltuq6m3sxzzrkfy6wetemiqvbdgnitkjwlcduswh3cvsccxy | Directory |   ↳ /by/procrastinatorily
 ```
 
 ### Sharded file in directory, byte ranges
@@ -549,15 +549,15 @@ All blocks of the file.
 [testmark]:# (test/sharded_file_in_directory_byte_ranges/0:*/execution)
 ```
 bafybeifrrglx2issn2had5rtstn3xltla6vxmpjfwfz7o3hapvkynh4zoq | Directory | /
-bafybeiawxstujkmnv2doejkzfydtotgqreycncd7ro4ixxddeoahofwjkm | File      | ↳ /clippet.txt[0:1889755] (1889756 B)
-bafkreib56a35cuh7mavlzlradaysqqpqx6lr2sn3veahyb2yb3y7dq5aei | RawLeaf   |   ↳ /clippet.txt[0:256143] (256144 B)
-bafkreicjp7lobawh3bob4gjq63fmsz44sbsayf2xkwhf3jhme25y2tyzky | RawLeaf   |     /clippet.txt[256144:512287] (256144 B)
-bafkreigcn244ayqteak6lignqrxdomc456362t4uysw624ccy7yk3ysfey | RawLeaf   |     /clippet.txt[512288:768431] (256144 B)
-bafkreihbp4ur2mdgfqntlyvew7njve5pdjgtphr74ipmbebu7fofcn4fh4 | RawLeaf   |     /clippet.txt[768432:1024575] (256144 B)
-bafkreibggbasrddspulesc5zum23cx3fqdknvzi6dttlrjsiga7qanakdu | RawLeaf   |     /clippet.txt[1024576:1280719] (256144 B)
-bafkreibzp426cl6b3udplywqrmfpdm6witikihya6n5rfh724lwnn53oe4 | RawLeaf   |     /clippet.txt[1280720:1536863] (256144 B)
-bafkreic47cecyo4ko65fdmpfhaonqz2kk73sd6zacnvsdjofee62u7d3oe | RawLeaf   |     /clippet.txt[1536864:1793007] (256144 B)
-bafkreif6cdswphju3fd5onyiuoswxpstlskdydqh4s3rvgwvdjmx7zhpcq | RawLeaf   |     /clippet.txt[1793008:1889755] (96748 B)
+bafybeiawxstujkmnv2doejkzfydtotgqreycncd7ro4ixxddeoahofwjkm | File      | ↳ /clippet.txt [0:1889755] (1,889,756 B)
+bafkreib56a35cuh7mavlzlradaysqqpqx6lr2sn3veahyb2yb3y7dq5aei | RawLeaf   |   ↳ /clippet.txt [0:256143] (256,144 B)
+bafkreicjp7lobawh3bob4gjq63fmsz44sbsayf2xkwhf3jhme25y2tyzky | RawLeaf   |     /clippet.txt [256144:512287] (256,144 B)
+bafkreigcn244ayqteak6lignqrxdomc456362t4uysw624ccy7yk3ysfey | RawLeaf   |     /clippet.txt [512288:768431] (256,144 B)
+bafkreihbp4ur2mdgfqntlyvew7njve5pdjgtphr74ipmbebu7fofcn4fh4 | RawLeaf   |     /clippet.txt [768432:1024575] (256,144 B)
+bafkreibggbasrddspulesc5zum23cx3fqdknvzi6dttlrjsiga7qanakdu | RawLeaf   |     /clippet.txt [1024576:1280719] (256,144 B)
+bafkreibzp426cl6b3udplywqrmfpdm6witikihya6n5rfh724lwnn53oe4 | RawLeaf   |     /clippet.txt [1280720:1536863] (256,144 B)
+bafkreic47cecyo4ko65fdmpfhaonqz2kk73sd6zacnvsdjofee62u7d3oe | RawLeaf   |     /clippet.txt [1536864:1793007] (256,144 B)
+bafkreif6cdswphju3fd5onyiuoswxpstlskdydqh4s3rvgwvdjmx7zhpcq | RawLeaf   |     /clippet.txt [1793008:1889755] (96,748 B)
 ```
 
 #### 0:10
@@ -572,8 +572,8 @@ Only needs first block.
 [testmark]:# (test/sharded_file_in_directory_byte_ranges/0:10/execution)
 ```
 bafybeifrrglx2issn2had5rtstn3xltla6vxmpjfwfz7o3hapvkynh4zoq | Directory | /
-bafybeiawxstujkmnv2doejkzfydtotgqreycncd7ro4ixxddeoahofwjkm | File      | ↳ /clippet.txt[0:1889755] (1889756 B)
-bafkreib56a35cuh7mavlzlradaysqqpqx6lr2sn3veahyb2yb3y7dq5aei | RawLeaf   |   ↳ /clippet.txt[0:256143] (256144 B)
+bafybeiawxstujkmnv2doejkzfydtotgqreycncd7ro4ixxddeoahofwjkm | File      | ↳ /clippet.txt [0:1889755] (1,889,756 B)
+bafkreib56a35cuh7mavlzlradaysqqpqx6lr2sn3veahyb2yb3y7dq5aei | RawLeaf   |   ↳ /clippet.txt [0:256143] (256,144 B)
 ```
 
 #### 0:256143 first block only
@@ -588,8 +588,8 @@ Matches full byte range of first block only.
 [testmark]:# (test/sharded_file_in_directory_byte_ranges/0:256143/execution)
 ```
 bafybeifrrglx2issn2had5rtstn3xltla6vxmpjfwfz7o3hapvkynh4zoq | Directory | /
-bafybeiawxstujkmnv2doejkzfydtotgqreycncd7ro4ixxddeoahofwjkm | File      | ↳ /clippet.txt[0:1889755] (1889756 B)
-bafkreib56a35cuh7mavlzlradaysqqpqx6lr2sn3veahyb2yb3y7dq5aei | RawLeaf   |   ↳ /clippet.txt[0:256143] (256144 B)
+bafybeiawxstujkmnv2doejkzfydtotgqreycncd7ro4ixxddeoahofwjkm | File      | ↳ /clippet.txt [0:1889755] (1,889,756 B)
+bafkreib56a35cuh7mavlzlradaysqqpqx6lr2sn3veahyb2yb3y7dq5aei | RawLeaf   |   ↳ /clippet.txt [0:256143] (256,144 B)
 ```
 
 
@@ -605,9 +605,9 @@ Needs the first byte of the second block, so matches first two blocks.
 [testmark]:# (test/sharded_file_in_directory_byte_ranges/0:256144/execution)
 ```
 bafybeifrrglx2issn2had5rtstn3xltla6vxmpjfwfz7o3hapvkynh4zoq | Directory | /
-bafybeiawxstujkmnv2doejkzfydtotgqreycncd7ro4ixxddeoahofwjkm | File      | ↳ /clippet.txt[0:1889755] (1889756 B)
-bafkreib56a35cuh7mavlzlradaysqqpqx6lr2sn3veahyb2yb3y7dq5aei | RawLeaf   |   ↳ /clippet.txt[0:256143] (256144 B)
-bafkreicjp7lobawh3bob4gjq63fmsz44sbsayf2xkwhf3jhme25y2tyzky | RawLeaf   |     /clippet.txt[256144:512287] (256144 B)
+bafybeiawxstujkmnv2doejkzfydtotgqreycncd7ro4ixxddeoahofwjkm | File      | ↳ /clippet.txt [0:1889755] (1,889,756 B)
+bafkreib56a35cuh7mavlzlradaysqqpqx6lr2sn3veahyb2yb3y7dq5aei | RawLeaf   |   ↳ /clippet.txt [0:256143] (256,144 B)
+bafkreicjp7lobawh3bob4gjq63fmsz44sbsayf2xkwhf3jhme25y2tyzky | RawLeaf   |     /clippet.txt [256144:512287] (256,144 B)
 ```
 
 #### 0:1793007 second last block
@@ -622,14 +622,14 @@ Needs all but the last block to match.
 [testmark]:# (test/sharded_file_in_directory_byte_ranges/0:1793007/execution)
 ```
 bafybeifrrglx2issn2had5rtstn3xltla6vxmpjfwfz7o3hapvkynh4zoq | Directory | /
-bafybeiawxstujkmnv2doejkzfydtotgqreycncd7ro4ixxddeoahofwjkm | File      | ↳ /clippet.txt[0:1889755] (1889756 B)
-bafkreib56a35cuh7mavlzlradaysqqpqx6lr2sn3veahyb2yb3y7dq5aei | RawLeaf   |   ↳ /clippet.txt[0:256143] (256144 B)
-bafkreicjp7lobawh3bob4gjq63fmsz44sbsayf2xkwhf3jhme25y2tyzky | RawLeaf   |     /clippet.txt[256144:512287] (256144 B)
-bafkreigcn244ayqteak6lignqrxdomc456362t4uysw624ccy7yk3ysfey | RawLeaf   |     /clippet.txt[512288:768431] (256144 B)
-bafkreihbp4ur2mdgfqntlyvew7njve5pdjgtphr74ipmbebu7fofcn4fh4 | RawLeaf   |     /clippet.txt[768432:1024575] (256144 B)
-bafkreibggbasrddspulesc5zum23cx3fqdknvzi6dttlrjsiga7qanakdu | RawLeaf   |     /clippet.txt[1024576:1280719] (256144 B)
-bafkreibzp426cl6b3udplywqrmfpdm6witikihya6n5rfh724lwnn53oe4 | RawLeaf   |     /clippet.txt[1280720:1536863] (256144 B)
-bafkreic47cecyo4ko65fdmpfhaonqz2kk73sd6zacnvsdjofee62u7d3oe | RawLeaf   |     /clippet.txt[1536864:1793007] (256144 B)
+bafybeiawxstujkmnv2doejkzfydtotgqreycncd7ro4ixxddeoahofwjkm | File      | ↳ /clippet.txt [0:1889755] (1,889,756 B)
+bafkreib56a35cuh7mavlzlradaysqqpqx6lr2sn3veahyb2yb3y7dq5aei | RawLeaf   |   ↳ /clippet.txt [0:256143] (256,144 B)
+bafkreicjp7lobawh3bob4gjq63fmsz44sbsayf2xkwhf3jhme25y2tyzky | RawLeaf   |     /clippet.txt [256144:512287] (256,144 B)
+bafkreigcn244ayqteak6lignqrxdomc456362t4uysw624ccy7yk3ysfey | RawLeaf   |     /clippet.txt [512288:768431] (256,144 B)
+bafkreihbp4ur2mdgfqntlyvew7njve5pdjgtphr74ipmbebu7fofcn4fh4 | RawLeaf   |     /clippet.txt [768432:1024575] (256,144 B)
+bafkreibggbasrddspulesc5zum23cx3fqdknvzi6dttlrjsiga7qanakdu | RawLeaf   |     /clippet.txt [1024576:1280719] (256,144 B)
+bafkreibzp426cl6b3udplywqrmfpdm6witikihya6n5rfh724lwnn53oe4 | RawLeaf   |     /clippet.txt [1280720:1536863] (256,144 B)
+bafkreic47cecyo4ko65fdmpfhaonqz2kk73sd6zacnvsdjofee62u7d3oe | RawLeaf   |     /clippet.txt [1536864:1793007] (256,144 B)
 ```
 
 #### 0:1793008 last block boundary
@@ -644,15 +644,15 @@ Should match all blocks because it includes the first byte of the last block.
 [testmark]:# (test/sharded_file_in_directory_byte_ranges/0:1793008/execution)
 ```
 bafybeifrrglx2issn2had5rtstn3xltla6vxmpjfwfz7o3hapvkynh4zoq | Directory | /
-bafybeiawxstujkmnv2doejkzfydtotgqreycncd7ro4ixxddeoahofwjkm | File      | ↳ /clippet.txt[0:1889755] (1889756 B)
-bafkreib56a35cuh7mavlzlradaysqqpqx6lr2sn3veahyb2yb3y7dq5aei | RawLeaf   |   ↳ /clippet.txt[0:256143] (256144 B)
-bafkreicjp7lobawh3bob4gjq63fmsz44sbsayf2xkwhf3jhme25y2tyzky | RawLeaf   |     /clippet.txt[256144:512287] (256144 B)
-bafkreigcn244ayqteak6lignqrxdomc456362t4uysw624ccy7yk3ysfey | RawLeaf   |     /clippet.txt[512288:768431] (256144 B)
-bafkreihbp4ur2mdgfqntlyvew7njve5pdjgtphr74ipmbebu7fofcn4fh4 | RawLeaf   |     /clippet.txt[768432:1024575] (256144 B)
-bafkreibggbasrddspulesc5zum23cx3fqdknvzi6dttlrjsiga7qanakdu | RawLeaf   |     /clippet.txt[1024576:1280719] (256144 B)
-bafkreibzp426cl6b3udplywqrmfpdm6witikihya6n5rfh724lwnn53oe4 | RawLeaf   |     /clippet.txt[1280720:1536863] (256144 B)
-bafkreic47cecyo4ko65fdmpfhaonqz2kk73sd6zacnvsdjofee62u7d3oe | RawLeaf   |     /clippet.txt[1536864:1793007] (256144 B)
-bafkreif6cdswphju3fd5onyiuoswxpstlskdydqh4s3rvgwvdjmx7zhpcq | RawLeaf   |     /clippet.txt[1793008:1889755] (96748 B)
+bafybeiawxstujkmnv2doejkzfydtotgqreycncd7ro4ixxddeoahofwjkm | File      | ↳ /clippet.txt [0:1889755] (1,889,756 B)
+bafkreib56a35cuh7mavlzlradaysqqpqx6lr2sn3veahyb2yb3y7dq5aei | RawLeaf   |   ↳ /clippet.txt [0:256143] (256,144 B)
+bafkreicjp7lobawh3bob4gjq63fmsz44sbsayf2xkwhf3jhme25y2tyzky | RawLeaf   |     /clippet.txt [256144:512287] (256,144 B)
+bafkreigcn244ayqteak6lignqrxdomc456362t4uysw624ccy7yk3ysfey | RawLeaf   |     /clippet.txt [512288:768431] (256,144 B)
+bafkreihbp4ur2mdgfqntlyvew7njve5pdjgtphr74ipmbebu7fofcn4fh4 | RawLeaf   |     /clippet.txt [768432:1024575] (256,144 B)
+bafkreibggbasrddspulesc5zum23cx3fqdknvzi6dttlrjsiga7qanakdu | RawLeaf   |     /clippet.txt [1024576:1280719] (256,144 B)
+bafkreibzp426cl6b3udplywqrmfpdm6witikihya6n5rfh724lwnn53oe4 | RawLeaf   |     /clippet.txt [1280720:1536863] (256,144 B)
+bafkreic47cecyo4ko65fdmpfhaonqz2kk73sd6zacnvsdjofee62u7d3oe | RawLeaf   |     /clippet.txt [1536864:1793007] (256,144 B)
+bafkreif6cdswphju3fd5onyiuoswxpstlskdydqh4s3rvgwvdjmx7zhpcq | RawLeaf   |     /clippet.txt [1793008:1889755] (96,748 B)
 ```
 
 #### 0:1889755 full file
@@ -667,15 +667,15 @@ Precise byte boundaries start:finish.
 [testmark]:# (test/sharded_file_in_directory_byte_ranges/0:1889755/execution)
 ```
 bafybeifrrglx2issn2had5rtstn3xltla6vxmpjfwfz7o3hapvkynh4zoq | Directory | /
-bafybeiawxstujkmnv2doejkzfydtotgqreycncd7ro4ixxddeoahofwjkm | File      | ↳ /clippet.txt[0:1889755] (1889756 B)
-bafkreib56a35cuh7mavlzlradaysqqpqx6lr2sn3veahyb2yb3y7dq5aei | RawLeaf   |   ↳ /clippet.txt[0:256143] (256144 B)
-bafkreicjp7lobawh3bob4gjq63fmsz44sbsayf2xkwhf3jhme25y2tyzky | RawLeaf   |     /clippet.txt[256144:512287] (256144 B)
-bafkreigcn244ayqteak6lignqrxdomc456362t4uysw624ccy7yk3ysfey | RawLeaf   |     /clippet.txt[512288:768431] (256144 B)
-bafkreihbp4ur2mdgfqntlyvew7njve5pdjgtphr74ipmbebu7fofcn4fh4 | RawLeaf   |     /clippet.txt[768432:1024575] (256144 B)
-bafkreibggbasrddspulesc5zum23cx3fqdknvzi6dttlrjsiga7qanakdu | RawLeaf   |     /clippet.txt[1024576:1280719] (256144 B)
-bafkreibzp426cl6b3udplywqrmfpdm6witikihya6n5rfh724lwnn53oe4 | RawLeaf   |     /clippet.txt[1280720:1536863] (256144 B)
-bafkreic47cecyo4ko65fdmpfhaonqz2kk73sd6zacnvsdjofee62u7d3oe | RawLeaf   |     /clippet.txt[1536864:1793007] (256144 B)
-bafkreif6cdswphju3fd5onyiuoswxpstlskdydqh4s3rvgwvdjmx7zhpcq | RawLeaf   |     /clippet.txt[1793008:1889755] (96748 B)
+bafybeiawxstujkmnv2doejkzfydtotgqreycncd7ro4ixxddeoahofwjkm | File      | ↳ /clippet.txt [0:1889755] (1,889,756 B)
+bafkreib56a35cuh7mavlzlradaysqqpqx6lr2sn3veahyb2yb3y7dq5aei | RawLeaf   |   ↳ /clippet.txt [0:256143] (256,144 B)
+bafkreicjp7lobawh3bob4gjq63fmsz44sbsayf2xkwhf3jhme25y2tyzky | RawLeaf   |     /clippet.txt [256144:512287] (256,144 B)
+bafkreigcn244ayqteak6lignqrxdomc456362t4uysw624ccy7yk3ysfey | RawLeaf   |     /clippet.txt [512288:768431] (256,144 B)
+bafkreihbp4ur2mdgfqntlyvew7njve5pdjgtphr74ipmbebu7fofcn4fh4 | RawLeaf   |     /clippet.txt [768432:1024575] (256,144 B)
+bafkreibggbasrddspulesc5zum23cx3fqdknvzi6dttlrjsiga7qanakdu | RawLeaf   |     /clippet.txt [1024576:1280719] (256,144 B)
+bafkreibzp426cl6b3udplywqrmfpdm6witikihya6n5rfh724lwnn53oe4 | RawLeaf   |     /clippet.txt [1280720:1536863] (256,144 B)
+bafkreic47cecyo4ko65fdmpfhaonqz2kk73sd6zacnvsdjofee62u7d3oe | RawLeaf   |     /clippet.txt [1536864:1793007] (256,144 B)
+bafkreif6cdswphju3fd5onyiuoswxpstlskdydqh4s3rvgwvdjmx7zhpcq | RawLeaf   |     /clippet.txt [1793008:1889755] (96,748 B)
 ```
 
 #### 0:1889756 full file +1
@@ -690,15 +690,15 @@ Beyond the end of the file, so should be the same as 0:1889755.
 [testmark]:# (test/sharded_file_in_directory_byte_ranges/0:1889756/execution)
 ```
 bafybeifrrglx2issn2had5rtstn3xltla6vxmpjfwfz7o3hapvkynh4zoq | Directory | /
-bafybeiawxstujkmnv2doejkzfydtotgqreycncd7ro4ixxddeoahofwjkm | File      | ↳ /clippet.txt[0:1889755] (1889756 B)
-bafkreib56a35cuh7mavlzlradaysqqpqx6lr2sn3veahyb2yb3y7dq5aei | RawLeaf   |   ↳ /clippet.txt[0:256143] (256144 B)
-bafkreicjp7lobawh3bob4gjq63fmsz44sbsayf2xkwhf3jhme25y2tyzky | RawLeaf   |     /clippet.txt[256144:512287] (256144 B)
-bafkreigcn244ayqteak6lignqrxdomc456362t4uysw624ccy7yk3ysfey | RawLeaf   |     /clippet.txt[512288:768431] (256144 B)
-bafkreihbp4ur2mdgfqntlyvew7njve5pdjgtphr74ipmbebu7fofcn4fh4 | RawLeaf   |     /clippet.txt[768432:1024575] (256144 B)
-bafkreibggbasrddspulesc5zum23cx3fqdknvzi6dttlrjsiga7qanakdu | RawLeaf   |     /clippet.txt[1024576:1280719] (256144 B)
-bafkreibzp426cl6b3udplywqrmfpdm6witikihya6n5rfh724lwnn53oe4 | RawLeaf   |     /clippet.txt[1280720:1536863] (256144 B)
-bafkreic47cecyo4ko65fdmpfhaonqz2kk73sd6zacnvsdjofee62u7d3oe | RawLeaf   |     /clippet.txt[1536864:1793007] (256144 B)
-bafkreif6cdswphju3fd5onyiuoswxpstlskdydqh4s3rvgwvdjmx7zhpcq | RawLeaf   |     /clippet.txt[1793008:1889755] (96748 B)
+bafybeiawxstujkmnv2doejkzfydtotgqreycncd7ro4ixxddeoahofwjkm | File      | ↳ /clippet.txt [0:1889755] (1,889,756 B)
+bafkreib56a35cuh7mavlzlradaysqqpqx6lr2sn3veahyb2yb3y7dq5aei | RawLeaf   |   ↳ /clippet.txt [0:256143] (256,144 B)
+bafkreicjp7lobawh3bob4gjq63fmsz44sbsayf2xkwhf3jhme25y2tyzky | RawLeaf   |     /clippet.txt [256144:512287] (256,144 B)
+bafkreigcn244ayqteak6lignqrxdomc456362t4uysw624ccy7yk3ysfey | RawLeaf   |     /clippet.txt [512288:768431] (256,144 B)
+bafkreihbp4ur2mdgfqntlyvew7njve5pdjgtphr74ipmbebu7fofcn4fh4 | RawLeaf   |     /clippet.txt [768432:1024575] (256,144 B)
+bafkreibggbasrddspulesc5zum23cx3fqdknvzi6dttlrjsiga7qanakdu | RawLeaf   |     /clippet.txt [1024576:1280719] (256,144 B)
+bafkreibzp426cl6b3udplywqrmfpdm6witikihya6n5rfh724lwnn53oe4 | RawLeaf   |     /clippet.txt [1280720:1536863] (256,144 B)
+bafkreic47cecyo4ko65fdmpfhaonqz2kk73sd6zacnvsdjofee62u7d3oe | RawLeaf   |     /clippet.txt [1536864:1793007] (256,144 B)
+bafkreif6cdswphju3fd5onyiuoswxpstlskdydqh4s3rvgwvdjmx7zhpcq | RawLeaf   |     /clippet.txt [1793008:1889755] (96,748 B)
 ```
 
 #### 0:99999999
@@ -713,15 +713,15 @@ Beyond last byte, should match all blocks.
 [testmark]:# (test/sharded_file_in_directory_byte_ranges/0:99999999/execution)
 ```
 bafybeifrrglx2issn2had5rtstn3xltla6vxmpjfwfz7o3hapvkynh4zoq | Directory | /
-bafybeiawxstujkmnv2doejkzfydtotgqreycncd7ro4ixxddeoahofwjkm | File      | ↳ /clippet.txt[0:1889755] (1889756 B)
-bafkreib56a35cuh7mavlzlradaysqqpqx6lr2sn3veahyb2yb3y7dq5aei | RawLeaf   |   ↳ /clippet.txt[0:256143] (256144 B)
-bafkreicjp7lobawh3bob4gjq63fmsz44sbsayf2xkwhf3jhme25y2tyzky | RawLeaf   |     /clippet.txt[256144:512287] (256144 B)
-bafkreigcn244ayqteak6lignqrxdomc456362t4uysw624ccy7yk3ysfey | RawLeaf   |     /clippet.txt[512288:768431] (256144 B)
-bafkreihbp4ur2mdgfqntlyvew7njve5pdjgtphr74ipmbebu7fofcn4fh4 | RawLeaf   |     /clippet.txt[768432:1024575] (256144 B)
-bafkreibggbasrddspulesc5zum23cx3fqdknvzi6dttlrjsiga7qanakdu | RawLeaf   |     /clippet.txt[1024576:1280719] (256144 B)
-bafkreibzp426cl6b3udplywqrmfpdm6witikihya6n5rfh724lwnn53oe4 | RawLeaf   |     /clippet.txt[1280720:1536863] (256144 B)
-bafkreic47cecyo4ko65fdmpfhaonqz2kk73sd6zacnvsdjofee62u7d3oe | RawLeaf   |     /clippet.txt[1536864:1793007] (256144 B)
-bafkreif6cdswphju3fd5onyiuoswxpstlskdydqh4s3rvgwvdjmx7zhpcq | RawLeaf   |     /clippet.txt[1793008:1889755] (96748 B)
+bafybeiawxstujkmnv2doejkzfydtotgqreycncd7ro4ixxddeoahofwjkm | File      | ↳ /clippet.txt [0:1889755] (1,889,756 B)
+bafkreib56a35cuh7mavlzlradaysqqpqx6lr2sn3veahyb2yb3y7dq5aei | RawLeaf   |   ↳ /clippet.txt [0:256143] (256,144 B)
+bafkreicjp7lobawh3bob4gjq63fmsz44sbsayf2xkwhf3jhme25y2tyzky | RawLeaf   |     /clippet.txt [256144:512287] (256,144 B)
+bafkreigcn244ayqteak6lignqrxdomc456362t4uysw624ccy7yk3ysfey | RawLeaf   |     /clippet.txt [512288:768431] (256,144 B)
+bafkreihbp4ur2mdgfqntlyvew7njve5pdjgtphr74ipmbebu7fofcn4fh4 | RawLeaf   |     /clippet.txt [768432:1024575] (256,144 B)
+bafkreibggbasrddspulesc5zum23cx3fqdknvzi6dttlrjsiga7qanakdu | RawLeaf   |     /clippet.txt [1024576:1280719] (256,144 B)
+bafkreibzp426cl6b3udplywqrmfpdm6witikihya6n5rfh724lwnn53oe4 | RawLeaf   |     /clippet.txt [1280720:1536863] (256,144 B)
+bafkreic47cecyo4ko65fdmpfhaonqz2kk73sd6zacnvsdjofee62u7d3oe | RawLeaf   |     /clippet.txt [1536864:1793007] (256,144 B)
+bafkreif6cdswphju3fd5onyiuoswxpstlskdydqh4s3rvgwvdjmx7zhpcq | RawLeaf   |     /clippet.txt [1793008:1889755] (96,748 B)
 ```
 
 #### 1793008:* last block
@@ -736,8 +736,8 @@ Starts at the first byte of the last block.
 [testmark]:# (test/sharded_file_in_directory_byte_ranges/1793008:*/execution)
 ```
 bafybeifrrglx2issn2had5rtstn3xltla6vxmpjfwfz7o3hapvkynh4zoq | Directory | /
-bafybeiawxstujkmnv2doejkzfydtotgqreycncd7ro4ixxddeoahofwjkm | File      | ↳ /clippet.txt[0:1889755] (1889756 B)
-bafkreif6cdswphju3fd5onyiuoswxpstlskdydqh4s3rvgwvdjmx7zhpcq | RawLeaf   |   ↳ /clippet.txt[1793008:1889755] (96748 B)
+bafybeiawxstujkmnv2doejkzfydtotgqreycncd7ro4ixxddeoahofwjkm | File      | ↳ /clippet.txt [0:1889755] (1,889,756 B)
+bafkreif6cdswphju3fd5onyiuoswxpstlskdydqh4s3rvgwvdjmx7zhpcq | RawLeaf   |   ↳ /clippet.txt [1793008:1889755] (96,748 B)
 ```
 
 #### 1793007:* second last block boundary
@@ -752,9 +752,9 @@ Starts at the last byte of the second last block.
 [testmark]:# (test/sharded_file_in_directory_byte_ranges/1793007:*/execution)
 ```
 bafybeifrrglx2issn2had5rtstn3xltla6vxmpjfwfz7o3hapvkynh4zoq | Directory | /
-bafybeiawxstujkmnv2doejkzfydtotgqreycncd7ro4ixxddeoahofwjkm | File      | ↳ /clippet.txt[0:1889755] (1889756 B)
-bafkreic47cecyo4ko65fdmpfhaonqz2kk73sd6zacnvsdjofee62u7d3oe | RawLeaf   |   ↳ /clippet.txt[1536864:1793007] (256144 B)
-bafkreif6cdswphju3fd5onyiuoswxpstlskdydqh4s3rvgwvdjmx7zhpcq | RawLeaf   |     /clippet.txt[1793008:1889755] (96748 B)
+bafybeiawxstujkmnv2doejkzfydtotgqreycncd7ro4ixxddeoahofwjkm | File      | ↳ /clippet.txt [0:1889755] (1,889,756 B)
+bafkreic47cecyo4ko65fdmpfhaonqz2kk73sd6zacnvsdjofee62u7d3oe | RawLeaf   |   ↳ /clippet.txt [1536864:1793007] (256,144 B)
+bafkreif6cdswphju3fd5onyiuoswxpstlskdydqh4s3rvgwvdjmx7zhpcq | RawLeaf   |     /clippet.txt [1793008:1889755] (96,748 B)
 ```
 
 #### 256144:* all but first block
@@ -769,14 +769,14 @@ Starts at the first byte of the second block.
 [testmark]:# (test/sharded_file_in_directory_byte_ranges/256144:*/execution)
 ```
 bafybeifrrglx2issn2had5rtstn3xltla6vxmpjfwfz7o3hapvkynh4zoq | Directory | /
-bafybeiawxstujkmnv2doejkzfydtotgqreycncd7ro4ixxddeoahofwjkm | File      | ↳ /clippet.txt[0:1889755] (1889756 B)
-bafkreicjp7lobawh3bob4gjq63fmsz44sbsayf2xkwhf3jhme25y2tyzky | RawLeaf   |   ↳ /clippet.txt[256144:512287] (256144 B)
-bafkreigcn244ayqteak6lignqrxdomc456362t4uysw624ccy7yk3ysfey | RawLeaf   |     /clippet.txt[512288:768431] (256144 B)
-bafkreihbp4ur2mdgfqntlyvew7njve5pdjgtphr74ipmbebu7fofcn4fh4 | RawLeaf   |     /clippet.txt[768432:1024575] (256144 B)
-bafkreibggbasrddspulesc5zum23cx3fqdknvzi6dttlrjsiga7qanakdu | RawLeaf   |     /clippet.txt[1024576:1280719] (256144 B)
-bafkreibzp426cl6b3udplywqrmfpdm6witikihya6n5rfh724lwnn53oe4 | RawLeaf   |     /clippet.txt[1280720:1536863] (256144 B)
-bafkreic47cecyo4ko65fdmpfhaonqz2kk73sd6zacnvsdjofee62u7d3oe | RawLeaf   |     /clippet.txt[1536864:1793007] (256144 B)
-bafkreif6cdswphju3fd5onyiuoswxpstlskdydqh4s3rvgwvdjmx7zhpcq | RawLeaf   |     /clippet.txt[1793008:1889755] (96748 B)
+bafybeiawxstujkmnv2doejkzfydtotgqreycncd7ro4ixxddeoahofwjkm | File      | ↳ /clippet.txt [0:1889755] (1,889,756 B)
+bafkreicjp7lobawh3bob4gjq63fmsz44sbsayf2xkwhf3jhme25y2tyzky | RawLeaf   |   ↳ /clippet.txt [256144:512287] (256,144 B)
+bafkreigcn244ayqteak6lignqrxdomc456362t4uysw624ccy7yk3ysfey | RawLeaf   |     /clippet.txt [512288:768431] (256,144 B)
+bafkreihbp4ur2mdgfqntlyvew7njve5pdjgtphr74ipmbebu7fofcn4fh4 | RawLeaf   |     /clippet.txt [768432:1024575] (256,144 B)
+bafkreibggbasrddspulesc5zum23cx3fqdknvzi6dttlrjsiga7qanakdu | RawLeaf   |     /clippet.txt [1024576:1280719] (256,144 B)
+bafkreibzp426cl6b3udplywqrmfpdm6witikihya6n5rfh724lwnn53oe4 | RawLeaf   |     /clippet.txt [1280720:1536863] (256,144 B)
+bafkreic47cecyo4ko65fdmpfhaonqz2kk73sd6zacnvsdjofee62u7d3oe | RawLeaf   |     /clippet.txt [1536864:1793007] (256,144 B)
+bafkreif6cdswphju3fd5onyiuoswxpstlskdydqh4s3rvgwvdjmx7zhpcq | RawLeaf   |     /clippet.txt [1793008:1889755] (96,748 B)
 ```
 
 #### 256143:* first block boundary
@@ -791,15 +791,15 @@ Need all blocks to match this.
 [testmark]:# (test/sharded_file_in_directory_byte_ranges/256143:*/execution)
 ```
 bafybeifrrglx2issn2had5rtstn3xltla6vxmpjfwfz7o3hapvkynh4zoq | Directory | /
-bafybeiawxstujkmnv2doejkzfydtotgqreycncd7ro4ixxddeoahofwjkm | File      | ↳ /clippet.txt[0:1889755] (1889756 B)
-bafkreib56a35cuh7mavlzlradaysqqpqx6lr2sn3veahyb2yb3y7dq5aei | RawLeaf   |   ↳ /clippet.txt[0:256143] (256144 B)
-bafkreicjp7lobawh3bob4gjq63fmsz44sbsayf2xkwhf3jhme25y2tyzky | RawLeaf   |     /clippet.txt[256144:512287] (256144 B)
-bafkreigcn244ayqteak6lignqrxdomc456362t4uysw624ccy7yk3ysfey | RawLeaf   |     /clippet.txt[512288:768431] (256144 B)
-bafkreihbp4ur2mdgfqntlyvew7njve5pdjgtphr74ipmbebu7fofcn4fh4 | RawLeaf   |     /clippet.txt[768432:1024575] (256144 B)
-bafkreibggbasrddspulesc5zum23cx3fqdknvzi6dttlrjsiga7qanakdu | RawLeaf   |     /clippet.txt[1024576:1280719] (256144 B)
-bafkreibzp426cl6b3udplywqrmfpdm6witikihya6n5rfh724lwnn53oe4 | RawLeaf   |     /clippet.txt[1280720:1536863] (256144 B)
-bafkreic47cecyo4ko65fdmpfhaonqz2kk73sd6zacnvsdjofee62u7d3oe | RawLeaf   |     /clippet.txt[1536864:1793007] (256144 B)
-bafkreif6cdswphju3fd5onyiuoswxpstlskdydqh4s3rvgwvdjmx7zhpcq | RawLeaf   |     /clippet.txt[1793008:1889755] (96748 B)
+bafybeiawxstujkmnv2doejkzfydtotgqreycncd7ro4ixxddeoahofwjkm | File      | ↳ /clippet.txt [0:1889755] (1,889,756 B)
+bafkreib56a35cuh7mavlzlradaysqqpqx6lr2sn3veahyb2yb3y7dq5aei | RawLeaf   |   ↳ /clippet.txt [0:256143] (256,144 B)
+bafkreicjp7lobawh3bob4gjq63fmsz44sbsayf2xkwhf3jhme25y2tyzky | RawLeaf   |     /clippet.txt [256144:512287] (256,144 B)
+bafkreigcn244ayqteak6lignqrxdomc456362t4uysw624ccy7yk3ysfey | RawLeaf   |     /clippet.txt [512288:768431] (256,144 B)
+bafkreihbp4ur2mdgfqntlyvew7njve5pdjgtphr74ipmbebu7fofcn4fh4 | RawLeaf   |     /clippet.txt [768432:1024575] (256,144 B)
+bafkreibggbasrddspulesc5zum23cx3fqdknvzi6dttlrjsiga7qanakdu | RawLeaf   |     /clippet.txt [1024576:1280719] (256,144 B)
+bafkreibzp426cl6b3udplywqrmfpdm6witikihya6n5rfh724lwnn53oe4 | RawLeaf   |     /clippet.txt [1280720:1536863] (256,144 B)
+bafkreic47cecyo4ko65fdmpfhaonqz2kk73sd6zacnvsdjofee62u7d3oe | RawLeaf   |     /clippet.txt [1536864:1793007] (256,144 B)
+bafkreif6cdswphju3fd5onyiuoswxpstlskdydqh4s3rvgwvdjmx7zhpcq | RawLeaf   |     /clippet.txt [1793008:1889755] (96,748 B)
 ```
 
 #### 256143:256144 first and second boundary
@@ -812,9 +812,9 @@ bafkreif6cdswphju3fd5onyiuoswxpstlskdydqh4s3rvgwvdjmx7zhpcq | RawLeaf   |     /c
 [testmark]:# (test/sharded_file_in_directory_byte_ranges/256143:256144/execution)
 ```
 bafybeifrrglx2issn2had5rtstn3xltla6vxmpjfwfz7o3hapvkynh4zoq | Directory | /
-bafybeiawxstujkmnv2doejkzfydtotgqreycncd7ro4ixxddeoahofwjkm | File      | ↳ /clippet.txt[0:1889755] (1889756 B)
-bafkreib56a35cuh7mavlzlradaysqqpqx6lr2sn3veahyb2yb3y7dq5aei | RawLeaf   |   ↳ /clippet.txt[0:256143] (256144 B)
-bafkreicjp7lobawh3bob4gjq63fmsz44sbsayf2xkwhf3jhme25y2tyzky | RawLeaf   |     /clippet.txt[256144:512287] (256144 B)
+bafybeiawxstujkmnv2doejkzfydtotgqreycncd7ro4ixxddeoahofwjkm | File      | ↳ /clippet.txt [0:1889755] (1,889,756 B)
+bafkreib56a35cuh7mavlzlradaysqqpqx6lr2sn3veahyb2yb3y7dq5aei | RawLeaf   |   ↳ /clippet.txt [0:256143] (256,144 B)
+bafkreicjp7lobawh3bob4gjq63fmsz44sbsayf2xkwhf3jhme25y2tyzky | RawLeaf   |     /clippet.txt [256144:512287] (256,144 B)
 ```
 
 #### 256144:256144 second only
@@ -829,8 +829,8 @@ Matching a single byte at the start of the second block
 [testmark]:# (test/sharded_file_in_directory_byte_ranges/256144:256144/execution)
 ```
 bafybeifrrglx2issn2had5rtstn3xltla6vxmpjfwfz7o3hapvkynh4zoq | Directory | /
-bafybeiawxstujkmnv2doejkzfydtotgqreycncd7ro4ixxddeoahofwjkm | File      | ↳ /clippet.txt[0:1889755] (1889756 B)
-bafkreicjp7lobawh3bob4gjq63fmsz44sbsayf2xkwhf3jhme25y2tyzky | RawLeaf   |   ↳ /clippet.txt[256144:512287] (256144 B)
+bafybeiawxstujkmnv2doejkzfydtotgqreycncd7ro4ixxddeoahofwjkm | File      | ↳ /clippet.txt [0:1889755] (1,889,756 B)
+bafkreicjp7lobawh3bob4gjq63fmsz44sbsayf2xkwhf3jhme25y2tyzky | RawLeaf   |   ↳ /clippet.txt [256144:512287] (256,144 B)
 ```
 
 #### 512287:512287 second only
@@ -845,8 +845,8 @@ Matching a single byte at the end of the second block
 [testmark]:# (test/sharded_file_in_directory_byte_ranges/512287:512287/execution)
 ```
 bafybeifrrglx2issn2had5rtstn3xltla6vxmpjfwfz7o3hapvkynh4zoq | Directory | /
-bafybeiawxstujkmnv2doejkzfydtotgqreycncd7ro4ixxddeoahofwjkm | File      | ↳ /clippet.txt[0:1889755] (1889756 B)
-bafkreicjp7lobawh3bob4gjq63fmsz44sbsayf2xkwhf3jhme25y2tyzky | RawLeaf   |   ↳ /clippet.txt[256144:512287] (256144 B)
+bafybeiawxstujkmnv2doejkzfydtotgqreycncd7ro4ixxddeoahofwjkm | File      | ↳ /clippet.txt [0:1889755] (1,889,756 B)
+bafkreicjp7lobawh3bob4gjq63fmsz44sbsayf2xkwhf3jhme25y2tyzky | RawLeaf   |   ↳ /clippet.txt [256144:512287] (256,144 B)
 ```
 
 #### 256143:1793008 full file, boundaries
@@ -861,15 +861,15 @@ Matching this needs all blocks, including one byte from first and last
 [testmark]:# (test/sharded_file_in_directory_byte_ranges/256143:1793008/execution)
 ```
 bafybeifrrglx2issn2had5rtstn3xltla6vxmpjfwfz7o3hapvkynh4zoq | Directory | /
-bafybeiawxstujkmnv2doejkzfydtotgqreycncd7ro4ixxddeoahofwjkm | File      | ↳ /clippet.txt[0:1889755] (1889756 B)
-bafkreib56a35cuh7mavlzlradaysqqpqx6lr2sn3veahyb2yb3y7dq5aei | RawLeaf   |   ↳ /clippet.txt[0:256143] (256144 B)
-bafkreicjp7lobawh3bob4gjq63fmsz44sbsayf2xkwhf3jhme25y2tyzky | RawLeaf   |     /clippet.txt[256144:512287] (256144 B)
-bafkreigcn244ayqteak6lignqrxdomc456362t4uysw624ccy7yk3ysfey | RawLeaf   |     /clippet.txt[512288:768431] (256144 B)
-bafkreihbp4ur2mdgfqntlyvew7njve5pdjgtphr74ipmbebu7fofcn4fh4 | RawLeaf   |     /clippet.txt[768432:1024575] (256144 B)
-bafkreibggbasrddspulesc5zum23cx3fqdknvzi6dttlrjsiga7qanakdu | RawLeaf   |     /clippet.txt[1024576:1280719] (256144 B)
-bafkreibzp426cl6b3udplywqrmfpdm6witikihya6n5rfh724lwnn53oe4 | RawLeaf   |     /clippet.txt[1280720:1536863] (256144 B)
-bafkreic47cecyo4ko65fdmpfhaonqz2kk73sd6zacnvsdjofee62u7d3oe | RawLeaf   |     /clippet.txt[1536864:1793007] (256144 B)
-bafkreif6cdswphju3fd5onyiuoswxpstlskdydqh4s3rvgwvdjmx7zhpcq | RawLeaf   |     /clippet.txt[1793008:1889755] (96748 B)
+bafybeiawxstujkmnv2doejkzfydtotgqreycncd7ro4ixxddeoahofwjkm | File      | ↳ /clippet.txt [0:1889755] (1,889,756 B)
+bafkreib56a35cuh7mavlzlradaysqqpqx6lr2sn3veahyb2yb3y7dq5aei | RawLeaf   |   ↳ /clippet.txt [0:256143] (256,144 B)
+bafkreicjp7lobawh3bob4gjq63fmsz44sbsayf2xkwhf3jhme25y2tyzky | RawLeaf   |     /clippet.txt [256144:512287] (256,144 B)
+bafkreigcn244ayqteak6lignqrxdomc456362t4uysw624ccy7yk3ysfey | RawLeaf   |     /clippet.txt [512288:768431] (256,144 B)
+bafkreihbp4ur2mdgfqntlyvew7njve5pdjgtphr74ipmbebu7fofcn4fh4 | RawLeaf   |     /clippet.txt [768432:1024575] (256,144 B)
+bafkreibggbasrddspulesc5zum23cx3fqdknvzi6dttlrjsiga7qanakdu | RawLeaf   |     /clippet.txt [1024576:1280719] (256,144 B)
+bafkreibzp426cl6b3udplywqrmfpdm6witikihya6n5rfh724lwnn53oe4 | RawLeaf   |     /clippet.txt [1280720:1536863] (256,144 B)
+bafkreic47cecyo4ko65fdmpfhaonqz2kk73sd6zacnvsdjofee62u7d3oe | RawLeaf   |     /clippet.txt [1536864:1793007] (256,144 B)
+bafkreif6cdswphju3fd5onyiuoswxpstlskdydqh4s3rvgwvdjmx7zhpcq | RawLeaf   |     /clippet.txt [1793008:1889755] (96,748 B)
 ```
 
 #### 256144:1793007 inner blocks, boundaries
@@ -884,13 +884,13 @@ Matching this only requires the middle blocks, excluding the first and last
 [testmark]:# (test/sharded_file_in_directory_byte_ranges/256144:1793007/execution)
 ```
 bafybeifrrglx2issn2had5rtstn3xltla6vxmpjfwfz7o3hapvkynh4zoq | Directory | /
-bafybeiawxstujkmnv2doejkzfydtotgqreycncd7ro4ixxddeoahofwjkm | File      | ↳ /clippet.txt[0:1889755] (1889756 B)
-bafkreicjp7lobawh3bob4gjq63fmsz44sbsayf2xkwhf3jhme25y2tyzky | RawLeaf   |   ↳ /clippet.txt[256144:512287] (256144 B)
-bafkreigcn244ayqteak6lignqrxdomc456362t4uysw624ccy7yk3ysfey | RawLeaf   |     /clippet.txt[512288:768431] (256144 B)
-bafkreihbp4ur2mdgfqntlyvew7njve5pdjgtphr74ipmbebu7fofcn4fh4 | RawLeaf   |     /clippet.txt[768432:1024575] (256144 B)
-bafkreibggbasrddspulesc5zum23cx3fqdknvzi6dttlrjsiga7qanakdu | RawLeaf   |     /clippet.txt[1024576:1280719] (256144 B)
-bafkreibzp426cl6b3udplywqrmfpdm6witikihya6n5rfh724lwnn53oe4 | RawLeaf   |     /clippet.txt[1280720:1536863] (256144 B)
-bafkreic47cecyo4ko65fdmpfhaonqz2kk73sd6zacnvsdjofee62u7d3oe | RawLeaf   |     /clippet.txt[1536864:1793007] (256144 B)
+bafybeiawxstujkmnv2doejkzfydtotgqreycncd7ro4ixxddeoahofwjkm | File      | ↳ /clippet.txt [0:1889755] (1,889,756 B)
+bafkreicjp7lobawh3bob4gjq63fmsz44sbsayf2xkwhf3jhme25y2tyzky | RawLeaf   |   ↳ /clippet.txt [256144:512287] (256,144 B)
+bafkreigcn244ayqteak6lignqrxdomc456362t4uysw624ccy7yk3ysfey | RawLeaf   |     /clippet.txt [512288:768431] (256,144 B)
+bafkreihbp4ur2mdgfqntlyvew7njve5pdjgtphr74ipmbebu7fofcn4fh4 | RawLeaf   |     /clippet.txt [768432:1024575] (256,144 B)
+bafkreibggbasrddspulesc5zum23cx3fqdknvzi6dttlrjsiga7qanakdu | RawLeaf   |     /clippet.txt [1024576:1280719] (256,144 B)
+bafkreibzp426cl6b3udplywqrmfpdm6witikihya6n5rfh724lwnn53oe4 | RawLeaf   |     /clippet.txt [1280720:1536863] (256,144 B)
+bafkreic47cecyo4ko65fdmpfhaonqz2kk73sd6zacnvsdjofee62u7d3oe | RawLeaf   |     /clippet.txt [1536864:1793007] (256,144 B)
 ```
 
 #### 0:-1
@@ -905,15 +905,15 @@ All blocks of the file.
 [testmark]:# (test/sharded_file_in_directory_byte_ranges/0:-1/execution)
 ```
 bafybeifrrglx2issn2had5rtstn3xltla6vxmpjfwfz7o3hapvkynh4zoq | Directory | /
-bafybeiawxstujkmnv2doejkzfydtotgqreycncd7ro4ixxddeoahofwjkm | File      | ↳ /clippet.txt[0:1889755] (1889756 B)
-bafkreib56a35cuh7mavlzlradaysqqpqx6lr2sn3veahyb2yb3y7dq5aei | RawLeaf   |   ↳ /clippet.txt[0:256143] (256144 B)
-bafkreicjp7lobawh3bob4gjq63fmsz44sbsayf2xkwhf3jhme25y2tyzky | RawLeaf   |     /clippet.txt[256144:512287] (256144 B)
-bafkreigcn244ayqteak6lignqrxdomc456362t4uysw624ccy7yk3ysfey | RawLeaf   |     /clippet.txt[512288:768431] (256144 B)
-bafkreihbp4ur2mdgfqntlyvew7njve5pdjgtphr74ipmbebu7fofcn4fh4 | RawLeaf   |     /clippet.txt[768432:1024575] (256144 B)
-bafkreibggbasrddspulesc5zum23cx3fqdknvzi6dttlrjsiga7qanakdu | RawLeaf   |     /clippet.txt[1024576:1280719] (256144 B)
-bafkreibzp426cl6b3udplywqrmfpdm6witikihya6n5rfh724lwnn53oe4 | RawLeaf   |     /clippet.txt[1280720:1536863] (256144 B)
-bafkreic47cecyo4ko65fdmpfhaonqz2kk73sd6zacnvsdjofee62u7d3oe | RawLeaf   |     /clippet.txt[1536864:1793007] (256144 B)
-bafkreif6cdswphju3fd5onyiuoswxpstlskdydqh4s3rvgwvdjmx7zhpcq | RawLeaf   |     /clippet.txt[1793008:1889755] (96748 B)
+bafybeiawxstujkmnv2doejkzfydtotgqreycncd7ro4ixxddeoahofwjkm | File      | ↳ /clippet.txt [0:1889755] (1,889,756 B)
+bafkreib56a35cuh7mavlzlradaysqqpqx6lr2sn3veahyb2yb3y7dq5aei | RawLeaf   |   ↳ /clippet.txt [0:256143] (256,144 B)
+bafkreicjp7lobawh3bob4gjq63fmsz44sbsayf2xkwhf3jhme25y2tyzky | RawLeaf   |     /clippet.txt [256144:512287] (256,144 B)
+bafkreigcn244ayqteak6lignqrxdomc456362t4uysw624ccy7yk3ysfey | RawLeaf   |     /clippet.txt [512288:768431] (256,144 B)
+bafkreihbp4ur2mdgfqntlyvew7njve5pdjgtphr74ipmbebu7fofcn4fh4 | RawLeaf   |     /clippet.txt [768432:1024575] (256,144 B)
+bafkreibggbasrddspulesc5zum23cx3fqdknvzi6dttlrjsiga7qanakdu | RawLeaf   |     /clippet.txt [1024576:1280719] (256,144 B)
+bafkreibzp426cl6b3udplywqrmfpdm6witikihya6n5rfh724lwnn53oe4 | RawLeaf   |     /clippet.txt [1280720:1536863] (256,144 B)
+bafkreic47cecyo4ko65fdmpfhaonqz2kk73sd6zacnvsdjofee62u7d3oe | RawLeaf   |     /clippet.txt [1536864:1793007] (256,144 B)
+bafkreif6cdswphju3fd5onyiuoswxpstlskdydqh4s3rvgwvdjmx7zhpcq | RawLeaf   |     /clippet.txt [1793008:1889755] (96,748 B)
 ```
 
 #### -10:*
@@ -928,8 +928,8 @@ Only needs the last block.
 [testmark]:# (test/sharded_file_in_directory_byte_ranges/-10:*/execution)
 ```
 bafybeifrrglx2issn2had5rtstn3xltla6vxmpjfwfz7o3hapvkynh4zoq | Directory | /
-bafybeiawxstujkmnv2doejkzfydtotgqreycncd7ro4ixxddeoahofwjkm | File      | ↳ /clippet.txt[0:1889755] (1889756 B)
-bafkreif6cdswphju3fd5onyiuoswxpstlskdydqh4s3rvgwvdjmx7zhpcq | RawLeaf   |     /clippet.txt[1793008:1889755] (96748 B)
+bafybeiawxstujkmnv2doejkzfydtotgqreycncd7ro4ixxddeoahofwjkm | File      | ↳ /clippet.txt [0:1889755] (1,889,756 B)
+bafkreif6cdswphju3fd5onyiuoswxpstlskdydqh4s3rvgwvdjmx7zhpcq | RawLeaf   |   ↳ /clippet.txt [1793008:1889755] (96,748 B)
 ```
 
 #### 0:-1889755
@@ -944,8 +944,8 @@ Only needs the first block.
 [testmark]:# (test/sharded_file_in_directory_byte_ranges/0:-1889755/execution)
 ```
 bafybeifrrglx2issn2had5rtstn3xltla6vxmpjfwfz7o3hapvkynh4zoq | Directory | /
-bafybeiawxstujkmnv2doejkzfydtotgqreycncd7ro4ixxddeoahofwjkm | File      | ↳ /clippet.txt[0:1889755] (1889756 B)
-bafkreib56a35cuh7mavlzlradaysqqpqx6lr2sn3veahyb2yb3y7dq5aei | RawLeaf   |   ↳ /clippet.txt[0:256143] (256144 B)
+bafybeiawxstujkmnv2doejkzfydtotgqreycncd7ro4ixxddeoahofwjkm | File      | ↳ /clippet.txt [0:1889755] (1,889,756 B)
+bafkreib56a35cuh7mavlzlradaysqqpqx6lr2sn3veahyb2yb3y7dq5aei | RawLeaf   |   ↳ /clippet.txt [0:256143] (256,144 B)
 ```
 
 #### 0:-1889756
@@ -960,7 +960,7 @@ Doesn't match any blocks, 0:0.
 [testmark]:# (test/sharded_file_in_directory_byte_ranges/0:-1889756/execution)
 ```
 bafybeifrrglx2issn2had5rtstn3xltla6vxmpjfwfz7o3hapvkynh4zoq | Directory | /
-bafybeiawxstujkmnv2doejkzfydtotgqreycncd7ro4ixxddeoahofwjkm | File      | ↳ /clippet.txt[0:1889755] (1889756 B)
+bafybeiawxstujkmnv2doejkzfydtotgqreycncd7ro4ixxddeoahofwjkm | File      | ↳ /clippet.txt [0:1889755] (1,889,756 B)
 ```
 
 #### 0:-999999999
@@ -975,7 +975,7 @@ Doesn't match any blocks, 0:0.
 [testmark]:# (test/sharded_file_in_directory_byte_ranges/0:-999999999/execution)
 ```
 bafybeifrrglx2issn2had5rtstn3xltla6vxmpjfwfz7o3hapvkynh4zoq | Directory | /
-bafybeiawxstujkmnv2doejkzfydtotgqreycncd7ro4ixxddeoahofwjkm | File      | ↳ /clippet.txt[0:1889755] (1889756 B)
+bafybeiawxstujkmnv2doejkzfydtotgqreycncd7ro4ixxddeoahofwjkm | File      | ↳ /clippet.txt [0:1889755] (1,889,756 B)
 ```
 
 #### 0:-96747 last block boundary (incl)
@@ -990,15 +990,15 @@ Should match all blocks because it includes the first byte of the last block.
 [testmark]:# (test/sharded_file_in_directory_byte_ranges/0:-96747/execution)
 ```
 bafybeifrrglx2issn2had5rtstn3xltla6vxmpjfwfz7o3hapvkynh4zoq | Directory | /
-bafybeiawxstujkmnv2doejkzfydtotgqreycncd7ro4ixxddeoahofwjkm | File      | ↳ /clippet.txt[0:1889755] (1889756 B)
-bafkreib56a35cuh7mavlzlradaysqqpqx6lr2sn3veahyb2yb3y7dq5aei | RawLeaf   |   ↳ /clippet.txt[0:256143] (256144 B)
-bafkreicjp7lobawh3bob4gjq63fmsz44sbsayf2xkwhf3jhme25y2tyzky | RawLeaf   |     /clippet.txt[256144:512287] (256144 B)
-bafkreigcn244ayqteak6lignqrxdomc456362t4uysw624ccy7yk3ysfey | RawLeaf   |     /clippet.txt[512288:768431] (256144 B)
-bafkreihbp4ur2mdgfqntlyvew7njve5pdjgtphr74ipmbebu7fofcn4fh4 | RawLeaf   |     /clippet.txt[768432:1024575] (256144 B)
-bafkreibggbasrddspulesc5zum23cx3fqdknvzi6dttlrjsiga7qanakdu | RawLeaf   |     /clippet.txt[1024576:1280719] (256144 B)
-bafkreibzp426cl6b3udplywqrmfpdm6witikihya6n5rfh724lwnn53oe4 | RawLeaf   |     /clippet.txt[1280720:1536863] (256144 B)
-bafkreic47cecyo4ko65fdmpfhaonqz2kk73sd6zacnvsdjofee62u7d3oe | RawLeaf   |     /clippet.txt[1536864:1793007] (256144 B)
-bafkreif6cdswphju3fd5onyiuoswxpstlskdydqh4s3rvgwvdjmx7zhpcq | RawLeaf   |     /clippet.txt[1793008:1889755] (96748 B)
+bafybeiawxstujkmnv2doejkzfydtotgqreycncd7ro4ixxddeoahofwjkm | File      | ↳ /clippet.txt [0:1889755] (1,889,756 B)
+bafkreib56a35cuh7mavlzlradaysqqpqx6lr2sn3veahyb2yb3y7dq5aei | RawLeaf   |   ↳ /clippet.txt [0:256143] (256,144 B)
+bafkreicjp7lobawh3bob4gjq63fmsz44sbsayf2xkwhf3jhme25y2tyzky | RawLeaf   |     /clippet.txt [256144:512287] (256,144 B)
+bafkreigcn244ayqteak6lignqrxdomc456362t4uysw624ccy7yk3ysfey | RawLeaf   |     /clippet.txt [512288:768431] (256,144 B)
+bafkreihbp4ur2mdgfqntlyvew7njve5pdjgtphr74ipmbebu7fofcn4fh4 | RawLeaf   |     /clippet.txt [768432:1024575] (256,144 B)
+bafkreibggbasrddspulesc5zum23cx3fqdknvzi6dttlrjsiga7qanakdu | RawLeaf   |     /clippet.txt [1024576:1280719] (256,144 B)
+bafkreibzp426cl6b3udplywqrmfpdm6witikihya6n5rfh724lwnn53oe4 | RawLeaf   |     /clippet.txt [1280720:1536863] (256,144 B)
+bafkreic47cecyo4ko65fdmpfhaonqz2kk73sd6zacnvsdjofee62u7d3oe | RawLeaf   |     /clippet.txt [1536864:1793007] (256,144 B)
+bafkreif6cdswphju3fd5onyiuoswxpstlskdydqh4s3rvgwvdjmx7zhpcq | RawLeaf   |     /clippet.txt [1793008:1889755] (96,748 B)
 ```
 
 #### 0:-96748 last block boundary (excl)
@@ -1013,14 +1013,14 @@ Should match all blocks but the last.
 [testmark]:# (test/sharded_file_in_directory_byte_ranges/0:-96748/execution)
 ```
 bafybeifrrglx2issn2had5rtstn3xltla6vxmpjfwfz7o3hapvkynh4zoq | Directory | /
-bafybeiawxstujkmnv2doejkzfydtotgqreycncd7ro4ixxddeoahofwjkm | File      | ↳ /clippet.txt[0:1889755] (1889756 B)
-bafkreib56a35cuh7mavlzlradaysqqpqx6lr2sn3veahyb2yb3y7dq5aei | RawLeaf   |   ↳ /clippet.txt[0:256143] (256144 B)
-bafkreicjp7lobawh3bob4gjq63fmsz44sbsayf2xkwhf3jhme25y2tyzky | RawLeaf   |     /clippet.txt[256144:512287] (256144 B)
-bafkreigcn244ayqteak6lignqrxdomc456362t4uysw624ccy7yk3ysfey | RawLeaf   |     /clippet.txt[512288:768431] (256144 B)
-bafkreihbp4ur2mdgfqntlyvew7njve5pdjgtphr74ipmbebu7fofcn4fh4 | RawLeaf   |     /clippet.txt[768432:1024575] (256144 B)
-bafkreibggbasrddspulesc5zum23cx3fqdknvzi6dttlrjsiga7qanakdu | RawLeaf   |     /clippet.txt[1024576:1280719] (256144 B)
-bafkreibzp426cl6b3udplywqrmfpdm6witikihya6n5rfh724lwnn53oe4 | RawLeaf   |     /clippet.txt[1280720:1536863] (256144 B)
-bafkreic47cecyo4ko65fdmpfhaonqz2kk73sd6zacnvsdjofee62u7d3oe | RawLeaf   |     /clippet.txt[1536864:1793007] (256144 B)
+bafybeiawxstujkmnv2doejkzfydtotgqreycncd7ro4ixxddeoahofwjkm | File      | ↳ /clippet.txt [0:1889755] (1,889,756 B)
+bafkreib56a35cuh7mavlzlradaysqqpqx6lr2sn3veahyb2yb3y7dq5aei | RawLeaf   |   ↳ /clippet.txt [0:256143] (256,144 B)
+bafkreicjp7lobawh3bob4gjq63fmsz44sbsayf2xkwhf3jhme25y2tyzky | RawLeaf   |     /clippet.txt [256144:512287] (256,144 B)
+bafkreigcn244ayqteak6lignqrxdomc456362t4uysw624ccy7yk3ysfey | RawLeaf   |     /clippet.txt [512288:768431] (256,144 B)
+bafkreihbp4ur2mdgfqntlyvew7njve5pdjgtphr74ipmbebu7fofcn4fh4 | RawLeaf   |     /clippet.txt [768432:1024575] (256,144 B)
+bafkreibggbasrddspulesc5zum23cx3fqdknvzi6dttlrjsiga7qanakdu | RawLeaf   |     /clippet.txt [1024576:1280719] (256,144 B)
+bafkreibzp426cl6b3udplywqrmfpdm6witikihya6n5rfh724lwnn53oe4 | RawLeaf   |     /clippet.txt [1280720:1536863] (256,144 B)
+bafkreic47cecyo4ko65fdmpfhaonqz2kk73sd6zacnvsdjofee62u7d3oe | RawLeaf   |     /clippet.txt [1536864:1793007] (256,144 B)
 ```
 
 #### 256143:-96747 middle blocks (incl)
@@ -1035,15 +1035,15 @@ Should match all blocks because it includes a byte on both the first and last bl
 [testmark]:# (test/sharded_file_in_directory_byte_ranges/256143:-96747/execution)
 ```
 bafybeifrrglx2issn2had5rtstn3xltla6vxmpjfwfz7o3hapvkynh4zoq | Directory | /
-bafybeiawxstujkmnv2doejkzfydtotgqreycncd7ro4ixxddeoahofwjkm | File      | ↳ /clippet.txt[0:1889755] (1889756 B)
-bafkreib56a35cuh7mavlzlradaysqqpqx6lr2sn3veahyb2yb3y7dq5aei | RawLeaf   |   ↳ /clippet.txt[0:256143] (256144 B)
-bafkreicjp7lobawh3bob4gjq63fmsz44sbsayf2xkwhf3jhme25y2tyzky | RawLeaf   |     /clippet.txt[256144:512287] (256144 B)
-bafkreigcn244ayqteak6lignqrxdomc456362t4uysw624ccy7yk3ysfey | RawLeaf   |     /clippet.txt[512288:768431] (256144 B)
-bafkreihbp4ur2mdgfqntlyvew7njve5pdjgtphr74ipmbebu7fofcn4fh4 | RawLeaf   |     /clippet.txt[768432:1024575] (256144 B)
-bafkreibggbasrddspulesc5zum23cx3fqdknvzi6dttlrjsiga7qanakdu | RawLeaf   |     /clippet.txt[1024576:1280719] (256144 B)
-bafkreibzp426cl6b3udplywqrmfpdm6witikihya6n5rfh724lwnn53oe4 | RawLeaf   |     /clippet.txt[1280720:1536863] (256144 B)
-bafkreic47cecyo4ko65fdmpfhaonqz2kk73sd6zacnvsdjofee62u7d3oe | RawLeaf   |     /clippet.txt[1536864:1793007] (256144 B)
-bafkreif6cdswphju3fd5onyiuoswxpstlskdydqh4s3rvgwvdjmx7zhpcq | RawLeaf   |     /clippet.txt[1793008:1889755] (96748 B)
+bafybeiawxstujkmnv2doejkzfydtotgqreycncd7ro4ixxddeoahofwjkm | File      | ↳ /clippet.txt [0:1889755] (1,889,756 B)
+bafkreib56a35cuh7mavlzlradaysqqpqx6lr2sn3veahyb2yb3y7dq5aei | RawLeaf   |   ↳ /clippet.txt [0:256143] (256,144 B)
+bafkreicjp7lobawh3bob4gjq63fmsz44sbsayf2xkwhf3jhme25y2tyzky | RawLeaf   |     /clippet.txt [256144:512287] (256,144 B)
+bafkreigcn244ayqteak6lignqrxdomc456362t4uysw624ccy7yk3ysfey | RawLeaf   |     /clippet.txt [512288:768431] (256,144 B)
+bafkreihbp4ur2mdgfqntlyvew7njve5pdjgtphr74ipmbebu7fofcn4fh4 | RawLeaf   |     /clippet.txt [768432:1024575] (256,144 B)
+bafkreibggbasrddspulesc5zum23cx3fqdknvzi6dttlrjsiga7qanakdu | RawLeaf   |     /clippet.txt [1024576:1280719] (256,144 B)
+bafkreibzp426cl6b3udplywqrmfpdm6witikihya6n5rfh724lwnn53oe4 | RawLeaf   |     /clippet.txt [1280720:1536863] (256,144 B)
+bafkreic47cecyo4ko65fdmpfhaonqz2kk73sd6zacnvsdjofee62u7d3oe | RawLeaf   |     /clippet.txt [1536864:1793007] (256,144 B)
+bafkreif6cdswphju3fd5onyiuoswxpstlskdydqh4s3rvgwvdjmx7zhpcq | RawLeaf   |     /clippet.txt [1793008:1889755] (96,748 B)
 ```
 
 #### 256144:-96748 middle blocks (excl)
@@ -1058,13 +1058,13 @@ Should match all middle blocks.
 [testmark]:# (test/sharded_file_in_directory_byte_ranges/256144:-96748/execution)
 ```
 bafybeifrrglx2issn2had5rtstn3xltla6vxmpjfwfz7o3hapvkynh4zoq | Directory | /
-bafybeiawxstujkmnv2doejkzfydtotgqreycncd7ro4ixxddeoahofwjkm | File      | ↳ /clippet.txt[0:1889755] (1889756 B)
-bafkreicjp7lobawh3bob4gjq63fmsz44sbsayf2xkwhf3jhme25y2tyzky | RawLeaf   |     /clippet.txt[256144:512287] (256144 B)
-bafkreigcn244ayqteak6lignqrxdomc456362t4uysw624ccy7yk3ysfey | RawLeaf   |     /clippet.txt[512288:768431] (256144 B)
-bafkreihbp4ur2mdgfqntlyvew7njve5pdjgtphr74ipmbebu7fofcn4fh4 | RawLeaf   |     /clippet.txt[768432:1024575] (256144 B)
-bafkreibggbasrddspulesc5zum23cx3fqdknvzi6dttlrjsiga7qanakdu | RawLeaf   |     /clippet.txt[1024576:1280719] (256144 B)
-bafkreibzp426cl6b3udplywqrmfpdm6witikihya6n5rfh724lwnn53oe4 | RawLeaf   |     /clippet.txt[1280720:1536863] (256144 B)
-bafkreic47cecyo4ko65fdmpfhaonqz2kk73sd6zacnvsdjofee62u7d3oe | RawLeaf   |     /clippet.txt[1536864:1793007] (256144 B)
+bafybeiawxstujkmnv2doejkzfydtotgqreycncd7ro4ixxddeoahofwjkm | File      | ↳ /clippet.txt [0:1889755] (1,889,756 B)
+bafkreicjp7lobawh3bob4gjq63fmsz44sbsayf2xkwhf3jhme25y2tyzky | RawLeaf   |   ↳ /clippet.txt [256144:512287] (256,144 B)
+bafkreigcn244ayqteak6lignqrxdomc456362t4uysw624ccy7yk3ysfey | RawLeaf   |     /clippet.txt [512288:768431] (256,144 B)
+bafkreihbp4ur2mdgfqntlyvew7njve5pdjgtphr74ipmbebu7fofcn4fh4 | RawLeaf   |     /clippet.txt [768432:1024575] (256,144 B)
+bafkreibggbasrddspulesc5zum23cx3fqdknvzi6dttlrjsiga7qanakdu | RawLeaf   |     /clippet.txt [1024576:1280719] (256,144 B)
+bafkreibzp426cl6b3udplywqrmfpdm6witikihya6n5rfh724lwnn53oe4 | RawLeaf   |     /clippet.txt [1280720:1536863] (256,144 B)
+bafkreic47cecyo4ko65fdmpfhaonqz2kk73sd6zacnvsdjofee62u7d3oe | RawLeaf   |     /clippet.txt [1536864:1793007] (256,144 B)
 ```
 
 ### Small file in directory, byte ranges
@@ -1082,9 +1082,9 @@ A single-block file in the root of the UnixFS DAG as the target, using byte rang
 ```
 bafybeifrrglx2issn2had5rtstn3xltla6vxmpjfwfz7o3hapvkynh4zoq | Directory | /
 bafybeie3mbyp7k77vrpiduaifyhdeqvusjn7qofzwtsp47yavyyb62z32y | HAMTShard | ↳ /Zigzagumptious
-bafybeigivdbrxmcixaqfap3rrs7ti5ycr7vj4xfbkjougq67k7ac5oz55a | HAMTShard |   ↳ <hamt>
-bafybeig2cw3hgc3oo4tpd5cqh7pfgrrzjdlenz3n2fredafr4l3ja7tvgy | Directory |     ↳ /Lickety-split
-bafkreifc732vu5ykpdctxxmpdsvdj4mmfrejf47lpq2suzhpdgxwudwohy | RawLeaf   |       ↳ /velociraptorious.csv[0:1822] (1823 B)
+bafybeigivdbrxmcixaqfap3rrs7ti5ycr7vj4xfbkjougq67k7ac5oz55a | HAMTShard |   ↳ /Zigzagumptious [2]
+bafybeig2cw3hgc3oo4tpd5cqh7pfgrrzjdlenz3n2fredafr4l3ja7tvgy | Directory |     ↳ /Zigzagumptious/Lickety-split
+bafkreifc732vu5ykpdctxxmpdsvdj4mmfrejf47lpq2suzhpdgxwudwohy | RawLeaf   |       ↳ /Zigzagumptious/Lickety-split/velociraptorious.csv [0:1822] (1,823 B)
 ```
 
 #### 0:0
@@ -1098,9 +1098,9 @@ bafkreifc732vu5ykpdctxxmpdsvdj4mmfrejf47lpq2suzhpdgxwudwohy | RawLeaf   |       
 ```
 bafybeifrrglx2issn2had5rtstn3xltla6vxmpjfwfz7o3hapvkynh4zoq | Directory | /
 bafybeie3mbyp7k77vrpiduaifyhdeqvusjn7qofzwtsp47yavyyb62z32y | HAMTShard | ↳ /Zigzagumptious
-bafybeigivdbrxmcixaqfap3rrs7ti5ycr7vj4xfbkjougq67k7ac5oz55a | HAMTShard |   ↳ <hamt>
-bafybeig2cw3hgc3oo4tpd5cqh7pfgrrzjdlenz3n2fredafr4l3ja7tvgy | Directory |     ↳ /Lickety-split
-bafkreifc732vu5ykpdctxxmpdsvdj4mmfrejf47lpq2suzhpdgxwudwohy | RawLeaf   |       ↳ /velociraptorious.csv[0:1822] (1823 B)
+bafybeigivdbrxmcixaqfap3rrs7ti5ycr7vj4xfbkjougq67k7ac5oz55a | HAMTShard |   ↳ /Zigzagumptious [2]
+bafybeig2cw3hgc3oo4tpd5cqh7pfgrrzjdlenz3n2fredafr4l3ja7tvgy | Directory |     ↳ /Zigzagumptious/Lickety-split
+bafkreifc732vu5ykpdctxxmpdsvdj4mmfrejf47lpq2suzhpdgxwudwohy | RawLeaf   |       ↳ /Zigzagumptious/Lickety-split/velociraptorious.csv [0:1822] (1,823 B)
 ```
 
 #### 0:10
@@ -1114,9 +1114,9 @@ bafkreifc732vu5ykpdctxxmpdsvdj4mmfrejf47lpq2suzhpdgxwudwohy | RawLeaf   |       
 ```
 bafybeifrrglx2issn2had5rtstn3xltla6vxmpjfwfz7o3hapvkynh4zoq | Directory | /
 bafybeie3mbyp7k77vrpiduaifyhdeqvusjn7qofzwtsp47yavyyb62z32y | HAMTShard | ↳ /Zigzagumptious
-bafybeigivdbrxmcixaqfap3rrs7ti5ycr7vj4xfbkjougq67k7ac5oz55a | HAMTShard |   ↳ <hamt>
-bafybeig2cw3hgc3oo4tpd5cqh7pfgrrzjdlenz3n2fredafr4l3ja7tvgy | Directory |     ↳ /Lickety-split
-bafkreifc732vu5ykpdctxxmpdsvdj4mmfrejf47lpq2suzhpdgxwudwohy | RawLeaf   |       ↳ /velociraptorious.csv[0:1822] (1823 B)
+bafybeigivdbrxmcixaqfap3rrs7ti5ycr7vj4xfbkjougq67k7ac5oz55a | HAMTShard |   ↳ /Zigzagumptious [2]
+bafybeig2cw3hgc3oo4tpd5cqh7pfgrrzjdlenz3n2fredafr4l3ja7tvgy | Directory |     ↳ /Zigzagumptious/Lickety-split
+bafkreifc732vu5ykpdctxxmpdsvdj4mmfrejf47lpq2suzhpdgxwudwohy | RawLeaf   |       ↳ /Zigzagumptious/Lickety-split/velociraptorious.csv [0:1822] (1,823 B)
 ```
 
 #### 1822:1823
@@ -1130,9 +1130,9 @@ bafkreifc732vu5ykpdctxxmpdsvdj4mmfrejf47lpq2suzhpdgxwudwohy | RawLeaf   |       
 ```
 bafybeifrrglx2issn2had5rtstn3xltla6vxmpjfwfz7o3hapvkynh4zoq | Directory | /
 bafybeie3mbyp7k77vrpiduaifyhdeqvusjn7qofzwtsp47yavyyb62z32y | HAMTShard | ↳ /Zigzagumptious
-bafybeigivdbrxmcixaqfap3rrs7ti5ycr7vj4xfbkjougq67k7ac5oz55a | HAMTShard |   ↳ <hamt>
-bafybeig2cw3hgc3oo4tpd5cqh7pfgrrzjdlenz3n2fredafr4l3ja7tvgy | Directory |     ↳ /Lickety-split
-bafkreifc732vu5ykpdctxxmpdsvdj4mmfrejf47lpq2suzhpdgxwudwohy | RawLeaf   |       ↳ /velociraptorious.csv[0:1822] (1823 B)
+bafybeigivdbrxmcixaqfap3rrs7ti5ycr7vj4xfbkjougq67k7ac5oz55a | HAMTShard |   ↳ /Zigzagumptious [2]
+bafybeig2cw3hgc3oo4tpd5cqh7pfgrrzjdlenz3n2fredafr4l3ja7tvgy | Directory |     ↳ /Zigzagumptious/Lickety-split
+bafkreifc732vu5ykpdctxxmpdsvdj4mmfrejf47lpq2suzhpdgxwudwohy | RawLeaf   |       ↳ /Zigzagumptious/Lickety-split/velociraptorious.csv [0:1822] (1,823 B)
 ```
 
 #### 1823:1823
@@ -1146,9 +1146,9 @@ bafkreifc732vu5ykpdctxxmpdsvdj4mmfrejf47lpq2suzhpdgxwudwohy | RawLeaf   |       
 ```
 bafybeifrrglx2issn2had5rtstn3xltla6vxmpjfwfz7o3hapvkynh4zoq | Directory | /
 bafybeie3mbyp7k77vrpiduaifyhdeqvusjn7qofzwtsp47yavyyb62z32y | HAMTShard | ↳ /Zigzagumptious
-bafybeigivdbrxmcixaqfap3rrs7ti5ycr7vj4xfbkjougq67k7ac5oz55a | HAMTShard |   ↳ <hamt>
-bafybeig2cw3hgc3oo4tpd5cqh7pfgrrzjdlenz3n2fredafr4l3ja7tvgy | Directory |     ↳ /Lickety-split
-bafkreifc732vu5ykpdctxxmpdsvdj4mmfrejf47lpq2suzhpdgxwudwohy | RawLeaf   |       ↳ /velociraptorious.csv[0:1822] (1823 B)
+bafybeigivdbrxmcixaqfap3rrs7ti5ycr7vj4xfbkjougq67k7ac5oz55a | HAMTShard |   ↳ /Zigzagumptious [2]
+bafybeig2cw3hgc3oo4tpd5cqh7pfgrrzjdlenz3n2fredafr4l3ja7tvgy | Directory |     ↳ /Zigzagumptious/Lickety-split
+bafkreifc732vu5ykpdctxxmpdsvdj4mmfrejf47lpq2suzhpdgxwudwohy | RawLeaf   |       ↳ /Zigzagumptious/Lickety-split/velociraptorious.csv [0:1822] (1,823 B)
 ```
 
 #### 1823:*
@@ -1162,9 +1162,9 @@ bafkreifc732vu5ykpdctxxmpdsvdj4mmfrejf47lpq2suzhpdgxwudwohy | RawLeaf   |       
 ```
 bafybeifrrglx2issn2had5rtstn3xltla6vxmpjfwfz7o3hapvkynh4zoq | Directory | /
 bafybeie3mbyp7k77vrpiduaifyhdeqvusjn7qofzwtsp47yavyyb62z32y | HAMTShard | ↳ /Zigzagumptious
-bafybeigivdbrxmcixaqfap3rrs7ti5ycr7vj4xfbkjougq67k7ac5oz55a | HAMTShard |   ↳ <hamt>
-bafybeig2cw3hgc3oo4tpd5cqh7pfgrrzjdlenz3n2fredafr4l3ja7tvgy | Directory |     ↳ /Lickety-split
-bafkreifc732vu5ykpdctxxmpdsvdj4mmfrejf47lpq2suzhpdgxwudwohy | RawLeaf   |       ↳ /velociraptorious.csv[0:1822] (1823 B)
+bafybeigivdbrxmcixaqfap3rrs7ti5ycr7vj4xfbkjougq67k7ac5oz55a | HAMTShard |   ↳ /Zigzagumptious [2]
+bafybeig2cw3hgc3oo4tpd5cqh7pfgrrzjdlenz3n2fredafr4l3ja7tvgy | Directory |     ↳ /Zigzagumptious/Lickety-split
+bafkreifc732vu5ykpdctxxmpdsvdj4mmfrejf47lpq2suzhpdgxwudwohy | RawLeaf   |       ↳ /Zigzagumptious/Lickety-split/velociraptorious.csv [0:1822] (1,823 B)
 ```
 
 
@@ -1179,9 +1179,9 @@ bafkreifc732vu5ykpdctxxmpdsvdj4mmfrejf47lpq2suzhpdgxwudwohy | RawLeaf   |       
 ```
 bafybeifrrglx2issn2had5rtstn3xltla6vxmpjfwfz7o3hapvkynh4zoq | Directory | /
 bafybeie3mbyp7k77vrpiduaifyhdeqvusjn7qofzwtsp47yavyyb62z32y | HAMTShard | ↳ /Zigzagumptious
-bafybeigivdbrxmcixaqfap3rrs7ti5ycr7vj4xfbkjougq67k7ac5oz55a | HAMTShard |   ↳ <hamt>
-bafybeig2cw3hgc3oo4tpd5cqh7pfgrrzjdlenz3n2fredafr4l3ja7tvgy | Directory |     ↳ /Lickety-split
-bafkreifc732vu5ykpdctxxmpdsvdj4mmfrejf47lpq2suzhpdgxwudwohy | RawLeaf   |       ↳ /velociraptorious.csv[0:1822] (1823 B)
+bafybeigivdbrxmcixaqfap3rrs7ti5ycr7vj4xfbkjougq67k7ac5oz55a | HAMTShard |   ↳ /Zigzagumptious [2]
+bafybeig2cw3hgc3oo4tpd5cqh7pfgrrzjdlenz3n2fredafr4l3ja7tvgy | Directory |     ↳ /Zigzagumptious/Lickety-split
+bafkreifc732vu5ykpdctxxmpdsvdj4mmfrejf47lpq2suzhpdgxwudwohy | RawLeaf   |       ↳ /Zigzagumptious/Lickety-split/velociraptorious.csv [0:1822] (1,823 B)
 ```
 
 #### -1823:*
@@ -1195,9 +1195,9 @@ bafkreifc732vu5ykpdctxxmpdsvdj4mmfrejf47lpq2suzhpdgxwudwohy | RawLeaf   |       
 ```
 bafybeifrrglx2issn2had5rtstn3xltla6vxmpjfwfz7o3hapvkynh4zoq | Directory | /
 bafybeie3mbyp7k77vrpiduaifyhdeqvusjn7qofzwtsp47yavyyb62z32y | HAMTShard | ↳ /Zigzagumptious
-bafybeigivdbrxmcixaqfap3rrs7ti5ycr7vj4xfbkjougq67k7ac5oz55a | HAMTShard |   ↳ <hamt>
-bafybeig2cw3hgc3oo4tpd5cqh7pfgrrzjdlenz3n2fredafr4l3ja7tvgy | Directory |     ↳ /Lickety-split
-bafkreifc732vu5ykpdctxxmpdsvdj4mmfrejf47lpq2suzhpdgxwudwohy | RawLeaf   |       ↳ /velociraptorious.csv[0:1822] (1823 B)
+bafybeigivdbrxmcixaqfap3rrs7ti5ycr7vj4xfbkjougq67k7ac5oz55a | HAMTShard |   ↳ /Zigzagumptious [2]
+bafybeig2cw3hgc3oo4tpd5cqh7pfgrrzjdlenz3n2fredafr4l3ja7tvgy | Directory |     ↳ /Zigzagumptious/Lickety-split
+bafkreifc732vu5ykpdctxxmpdsvdj4mmfrejf47lpq2suzhpdgxwudwohy | RawLeaf   |       ↳ /Zigzagumptious/Lickety-split/velociraptorious.csv [0:1822] (1,823 B)
 ```
 
 #### -1823:-1822
@@ -1211,9 +1211,9 @@ bafkreifc732vu5ykpdctxxmpdsvdj4mmfrejf47lpq2suzhpdgxwudwohy | RawLeaf   |       
 ```
 bafybeifrrglx2issn2had5rtstn3xltla6vxmpjfwfz7o3hapvkynh4zoq | Directory | /
 bafybeie3mbyp7k77vrpiduaifyhdeqvusjn7qofzwtsp47yavyyb62z32y | HAMTShard | ↳ /Zigzagumptious
-bafybeigivdbrxmcixaqfap3rrs7ti5ycr7vj4xfbkjougq67k7ac5oz55a | HAMTShard |   ↳ <hamt>
-bafybeig2cw3hgc3oo4tpd5cqh7pfgrrzjdlenz3n2fredafr4l3ja7tvgy | Directory |     ↳ /Lickety-split
-bafkreifc732vu5ykpdctxxmpdsvdj4mmfrejf47lpq2suzhpdgxwudwohy | RawLeaf   |       ↳ /velociraptorious.csv[0:1822] (1823 B)
+bafybeigivdbrxmcixaqfap3rrs7ti5ycr7vj4xfbkjougq67k7ac5oz55a | HAMTShard |   ↳ /Zigzagumptious [2]
+bafybeig2cw3hgc3oo4tpd5cqh7pfgrrzjdlenz3n2fredafr4l3ja7tvgy | Directory |     ↳ /Zigzagumptious/Lickety-split
+bafkreifc732vu5ykpdctxxmpdsvdj4mmfrejf47lpq2suzhpdgxwudwohy | RawLeaf   |       ↳ /Zigzagumptious/Lickety-split/velociraptorious.csv [0:1822] (1,823 B)
 ```
 
 ### Directory in a directory w/ byte range
@@ -1231,17 +1231,17 @@ Should perform the same as "Directory in a directory" case, as if the byte range
 ```
 bafybeifrrglx2issn2had5rtstn3xltla6vxmpjfwfz7o3hapvkynh4zoq | Directory | /
 bafybeigdgcs3nulbgu6vtnyesfgsaau2grbxzbxxdtpgolsfhtrpjx6mw4 | Directory | ↳ /by
-bafybeicsa4ltuq6m3sxzzrkfy6wetemiqvbdgnitkjwlcduswh3cvsccxy | Directory |   ↳ /procrastinatorily
-bafkreiaquanb6uzch2bkv7iltvwipmawjfihb7jgejqww63vgbqshderxq | RawLeaf   |     ↳ * (/F[0:727] (728 B))
-bafkreigtze43gghvasxpp3o6mklllhilbyzs63kzdtdlzpyaznk44vxnye | RawLeaf   |       * (/Gallivant.png[0:1339] (1340 B))
-bafkreifrkcg75acl2yu4jv65x5u7yzn2cnpezmx432p2v2lryzhwqyp63u | RawLeaf   |       * (/Oberon.xml[0:512] (513 B))
-bafkreiac4vqpljai2qjxx7mgs2equqcs4oq6lmmie2oiqhrkmwukuez3cm | RawLeaf   |       * (/Pandemonium[0:917] (918 B))
-bafkreiclovx7khthefexgfku4n7pndbqthj5xuiv6ymbd3cx2bve3qebby | RawLeaf   |       * (/gūþweard.docx[0:580] (581 B))
-bafkreiaqchjvbofqnpwoxwrtcvelnz5neg4y5buqchwgnxwoigjofmnol4 | RawLeaf   |       * (/juxtapositionally.png[0:2426] (2427 B))
-bafkreif3y7x7uailqhjjuketaa2p34gidoj7ynmnmviejtynydov75dkbq | RawLeaf   |       * (/sǣlācend[0:430] (431 B))
-bafkreias4xj2qbg36tyo4wirl2db2x2emh4lbfpwq7t3dexjos236a5wgu | RawLeaf   |       * (/t.png[0:57] (58 B))
-bafkreidzryf2cxeo5bfkxulhxlgr6axh5qfrsh4ns6jwfd2yutzpkcoaxu | RawLeaf   |       * (/ya.xml[0:417] (418 B))
-bafkreihys4i2ow3csfrhefnmwruwte2bv5ik223ocgbvq3ckwj7xdxzc2m | RawLeaf   |       * (/ætheling.docx[0:81] (82 B))
+bafybeicsa4ltuq6m3sxzzrkfy6wetemiqvbdgnitkjwlcduswh3cvsccxy | Directory |   ↳ /by/procrastinatorily
+bafkreiaquanb6uzch2bkv7iltvwipmawjfihb7jgejqww63vgbqshderxq | RawLeaf   |     ↳ /by/procrastinatorily/F [0:727] (728 B)
+bafkreigtze43gghvasxpp3o6mklllhilbyzs63kzdtdlzpyaznk44vxnye | RawLeaf   |       /by/procrastinatorily/Gallivant.png [0:1339] (1,340 B)
+bafkreifrkcg75acl2yu4jv65x5u7yzn2cnpezmx432p2v2lryzhwqyp63u | RawLeaf   |       /by/procrastinatorily/Oberon.xml [0:512] (513 B)
+bafkreiac4vqpljai2qjxx7mgs2equqcs4oq6lmmie2oiqhrkmwukuez3cm | RawLeaf   |       /by/procrastinatorily/Pandemonium [0:917] (918 B)
+bafkreiclovx7khthefexgfku4n7pndbqthj5xuiv6ymbd3cx2bve3qebby | RawLeaf   |       /by/procrastinatorily/gūþweard.docx [0:580] (581 B)
+bafkreiaqchjvbofqnpwoxwrtcvelnz5neg4y5buqchwgnxwoigjofmnol4 | RawLeaf   |       /by/procrastinatorily/juxtapositionally.png [0:2426] (2,427 B)
+bafkreif3y7x7uailqhjjuketaa2p34gidoj7ynmnmviejtynydov75dkbq | RawLeaf   |       /by/procrastinatorily/sǣlācend [0:430] (431 B)
+bafkreias4xj2qbg36tyo4wirl2db2x2emh4lbfpwq7t3dexjos236a5wgu | RawLeaf   |       /by/procrastinatorily/t.png [0:57] (58 B)
+bafkreidzryf2cxeo5bfkxulhxlgr6axh5qfrsh4ns6jwfd2yutzpkcoaxu | RawLeaf   |       /by/procrastinatorily/ya.xml [0:417] (418 B)
+bafkreihys4i2ow3csfrhefnmwruwte2bv5ik223ocgbvq3ckwj7xdxzc2m | RawLeaf   |       /by/procrastinatorily/ætheling.docx [0:81] (82 B)
 ```
 
 #### entity
@@ -1255,7 +1255,7 @@ bafkreihys4i2ow3csfrhefnmwruwte2bv5ik223ocgbvq3ckwj7xdxzc2m | RawLeaf   |       
 ```
 bafybeifrrglx2issn2had5rtstn3xltla6vxmpjfwfz7o3hapvkynh4zoq | Directory | /
 bafybeigdgcs3nulbgu6vtnyesfgsaau2grbxzbxxdtpgolsfhtrpjx6mw4 | Directory | ↳ /by
-bafybeicsa4ltuq6m3sxzzrkfy6wetemiqvbdgnitkjwlcduswh3cvsccxy | Directory |   ↳ /procrastinatorily
+bafybeicsa4ltuq6m3sxzzrkfy6wetemiqvbdgnitkjwlcduswh3cvsccxy | Directory |   ↳ /by/procrastinatorily
 ```
 
 #### block
@@ -1269,7 +1269,7 @@ bafybeicsa4ltuq6m3sxzzrkfy6wetemiqvbdgnitkjwlcduswh3cvsccxy | Directory |   ↳ 
 ```
 bafybeifrrglx2issn2had5rtstn3xltla6vxmpjfwfz7o3hapvkynh4zoq | Directory | /
 bafybeigdgcs3nulbgu6vtnyesfgsaau2grbxzbxxdtpgolsfhtrpjx6mw4 | Directory | ↳ /by
-bafybeicsa4ltuq6m3sxzzrkfy6wetemiqvbdgnitkjwlcduswh3cvsccxy | Directory |   ↳ /procrastinatorily
+bafybeicsa4ltuq6m3sxzzrkfy6wetemiqvbdgnitkjwlcduswh3cvsccxy | Directory |   ↳ /by/procrastinatorily
 ```
 
 ### Hamt in directory w/ byte range
@@ -1287,22 +1287,22 @@ Should perform the same as "Hamt in directory" case, as if the byte range wasn't
 ```
 bafybeifrrglx2issn2had5rtstn3xltla6vxmpjfwfz7o3hapvkynh4zoq | Directory | /
 bafybeie3mbyp7k77vrpiduaifyhdeqvusjn7qofzwtsp47yavyyb62z32y | HAMTShard | ↳ /Zigzagumptious
-bafybeiggzqpxmfbve7sutrmcwrlwpx4tkno536d7qdgd6hnhxf74t7gzee | HAMTShard |   ↳ /Zigzagumptious
-bafybeigfwz54atwgnklb72rfqqn2a3ywoontgf3b3kekxwoxalptx7gc3e | HAMTShard |     ↳ /Zigzagumptious
-bafybeifr3w3eyq2oi6hxwbfoblor7s5pfvu3m4xyyzovxlk4g5xgslsqui | HAMTShard |     /Zigzagumptious
-bafybeigivdbrxmcixaqfap3rrs7ti5ycr7vj4xfbkjougq67k7ac5oz55a | HAMTShard |     /Zigzagumptious
-bafybeid3cny2p7fwt4znzm3wjncsesdk2rdze5fm5rzxjpbethy4657j6m | HAMTShard |     /Zigzagumptious
-bafybeidivwpxv37o6p4ton3xcpmg64pwk4zqlkuge7isafgsgjsvb6ce2u | HAMTShard |     /Zigzagumptious
-bafybeib5ptplpmtmoyif4lxt5erw5diivp6so4s57lvgfigs53d7zpc4uu | HAMTShard |     /Zigzagumptious
-bafybeiafmairlfkvgqgticndcs4uomkll4h5xotvnnsw2j7cx3rjwrbh7i | HAMTShard |     ↳ /Zigzagumptious
-bafybeifjo6xz3onvav6cnpjjuroa7vbzegoxgg5jn6smfvgfcpzwzdaipa | HAMTShard |     /Zigzagumptious
-bafybeied5si546vcp6klpngu77kftitzffdlxk5ajaytadc3p3ptr7tvam | HAMTShard |     /Zigzagumptious
-bafybeiar4b5hfriv2pmmbj7npemto6bev7sqkn4jpstwqtaudexpetpg4m | HAMTShard |     /Zigzagumptious
-bafybeifcekpohkm7qaczfwrrzcdz6j3ykwntawdnp7b7fjfech75vxpwf4 | HAMTShard |     ↳ /Zigzagumptious
-bafybeihnejxifhvlunhcswhghhrbues366h7o4xqp3ziyeicrdt5473za4 | HAMTShard |     /Zigzagumptious
-bafybeihlijmc2xyfmomw4fx53mlz3gpt6svgfu3vfokm4wmyd4dagfup24 | HAMTShard |     /Zigzagumptious
-bafybeihjbh7kptdfaoanrkzhdpx2jwjacg5ncdlcbbwqlum6vwqfga5fii | HAMTShard |     /Zigzagumptious
-bafybeidaz5aob6tdurpnuj2xeqsjkarqudtono6x2kgbzrzv46ugp3g4ju | HAMTShard |     /Zigzagumptious
+bafybeiggzqpxmfbve7sutrmcwrlwpx4tkno536d7qdgd6hnhxf74t7gzee | HAMTShard |   ↳ /Zigzagumptious [0]
+bafybeigfwz54atwgnklb72rfqqn2a3ywoontgf3b3kekxwoxalptx7gc3e | HAMTShard |     ↳ /Zigzagumptious [0]
+bafybeifr3w3eyq2oi6hxwbfoblor7s5pfvu3m4xyyzovxlk4g5xgslsqui | HAMTShard |     /Zigzagumptious [1]
+bafybeigivdbrxmcixaqfap3rrs7ti5ycr7vj4xfbkjougq67k7ac5oz55a | HAMTShard |     /Zigzagumptious [2]
+bafybeid3cny2p7fwt4znzm3wjncsesdk2rdze5fm5rzxjpbethy4657j6m | HAMTShard |     /Zigzagumptious [4]
+bafybeidivwpxv37o6p4ton3xcpmg64pwk4zqlkuge7isafgsgjsvb6ce2u | HAMTShard |     /Zigzagumptious [6]
+bafybeib5ptplpmtmoyif4lxt5erw5diivp6so4s57lvgfigs53d7zpc4uu | HAMTShard |     /Zigzagumptious [7]
+bafybeiafmairlfkvgqgticndcs4uomkll4h5xotvnnsw2j7cx3rjwrbh7i | HAMTShard |     ↳ /Zigzagumptious [F]
+bafybeifjo6xz3onvav6cnpjjuroa7vbzegoxgg5jn6smfvgfcpzwzdaipa | HAMTShard |     /Zigzagumptious [8]
+bafybeied5si546vcp6klpngu77kftitzffdlxk5ajaytadc3p3ptr7tvam | HAMTShard |     /Zigzagumptious [9]
+bafybeiar4b5hfriv2pmmbj7npemto6bev7sqkn4jpstwqtaudexpetpg4m | HAMTShard |     /Zigzagumptious [A]
+bafybeifcekpohkm7qaczfwrrzcdz6j3ykwntawdnp7b7fjfech75vxpwf4 | HAMTShard |     ↳ /Zigzagumptious [B]
+bafybeihnejxifhvlunhcswhghhrbues366h7o4xqp3ziyeicrdt5473za4 | HAMTShard |     /Zigzagumptious [C]
+bafybeihlijmc2xyfmomw4fx53mlz3gpt6svgfu3vfokm4wmyd4dagfup24 | HAMTShard |     /Zigzagumptious [D]
+bafybeihjbh7kptdfaoanrkzhdpx2jwjacg5ncdlcbbwqlum6vwqfga5fii | HAMTShard |     /Zigzagumptious [E]
+bafybeidaz5aob6tdurpnuj2xeqsjkarqudtono6x2kgbzrzv46ugp3g4ju | HAMTShard |     /Zigzagumptious [F]
 ```
 
 #### block


### PR DESCRIPTION
Does not impact usage of these tests as they just use the first column, the CID, which hasn't changed in this PR. This is cosmetic changes to match the tool which I wrote to produce these which I've since improved a little.