### PR TITLE
fix: DAG-CBOR keys need to be CBOR strings

### DIFF
--- a/specs/codecs/dag-cbor/spec.md
+++ b/specs/codecs/dag-cbor/spec.md
@@ -41,7 +41,7 @@ The inclusion of the Multibase prefix exists for historical reasons and the iden
 
 ## Map Keys
 
-In DAG-CBOR, map keys must be strings, as defined by the [IPLD Data Model]. Other map keys, such as ints, are not supported and should be rejected when encountered.
+In DAG-CBOR, map keys must be strings. Other map keys, such as ints, are not supported and should be rejected when encountered.
 
 ## Strictness
 


### PR DESCRIPTION
DAG-CBOR must be valid CBOR, hence the keys in maps need to be CBOR strings and not IPLD Data Model strings, which theoretically allow for arbitrary bytes.