### PR TITLE
dag-cbor: remove note about map keys sort order

### DIFF
--- a/specs/codecs/dag-cbor/spec.md
+++ b/specs/codecs/dag-cbor/spec.md
@@ -28,7 +28,7 @@ DAG-CBOR uses the [Concise Binary Object Representation (CBOR)] data format, def
 The CBOR IPLD format is called DAG-CBOR to disambiguate it from regular CBOR. Most simple CBOR objects are valid DAG-CBOR. The primary differences are:
 
   * Tag `42` interpreted as CIDs, no other tags are supported.
-  * Maps may only be keyed by strings.
+  * Maps must only be keyed by strings.
   * Additional strictness requirements are applied to ensure canonical data encoding forms. See [Strictness](#strictness) below.
 
 ## Links
@@ -51,13 +51,11 @@ Therefore the DAG-CBOR codec must:
 
 1. Use no tags other than the CID tag (`42`). A valid DAG-CBOR encoder must not encode using any additional tags and a valid DAG-CBOR decoder must reject objects containing additional tags as invalid.
    * This includes any of the well defined tag numbers listed [section 3.4 of RFC 8949], such as dates, bignums, bigfloats, URIs, regular expressions and other complex, or simple values whether or not they map to the [IPLD Data Model].
-2. Use the "Deterministically Encoded CBOR" rule suggestions defined in [section 4.2 of RFC 8949] except for map key ordering, which follow the original rules as defined in [section 3.9 of RFC 7049]. Therefore, a valid DAG-CBOR encoder should produce encoded forms that adhere to the following rules, and a valid DAG-CBOR decoder should reject encoded forms not adhering to the following rules:
+2. Use the "Deterministically Encoded CBOR" rule suggestions defined in [section 4.2 of RFC 8949]. Therefore, a valid DAG-CBOR encoder should produce encoded forms that adhere to the following rules, and a valid DAG-CBOR decoder should reject encoded forms not adhering to the following rules:
    * Integer encoding must be as short as possible.
    * The expression of lengths in major types 2 through 5 must be as short as possible.
    * The expression of tag numbers (specifically only `42`) must be as short as possible for major type 6. Therefore, for valid DAG-CBOR, the only tag token that can appear is `0xd82a` - where `0xd8` is "major type 6 with 8-bit integer to follow" and `0x2a` is the number `42`.
-   * The keys in every map must be sorted length-first by the byte representation of the string keys, where:
-     - If two keys have different lengths, the shorter one sorts earlier;
-     - If two keys have the same length, the one with the lower value in (byte-wise) lexical order sorts earlier.
+   * The keys in every map must be sorted in (byte-wise) lexical order, including their major type 3 and length. Therefore, the keys are sorted by length first.
    * Indefinite-length items are not supported, only definite-length items are usable. This includes strings, bytes, lists and maps. The "break" token is also not supported.
 3. The only usable major type 7 minor types are those for encoding Floats (minors `25`, `26`, `27`), False (minor `20`), True (minor `21`) and Null (minor `22`).
    * [Simple Values] other than False, True and Null are not supported. This includes all registered or unregistered simple values that are encoded with a major type 7 other than False, True and Null.
@@ -153,7 +151,6 @@ The implications for DAG-CBOR of these limitations are:
 [IPLD content identifiers (CIDs) in CBOR]: https://github.com/ipld/cid-cbor/
 [section 3.4 of RFC 8949]: https://tools.ietf.org/html/rfc8949#section-3.4
 [section 4.2 of RFC 8949]: https://tools.ietf.org/html/rfc8949#section-4.2
-[section 3.9 of RFC 7049]: https://tools.ietf.org/html/rfc7049#section-3.9
 [Simple Values]: https://tools.ietf.org/html/rfc8949#section-2.1
 [section 5.1 of RFC 8949]: https://tools.ietf.org/html/rfc8949#section-5.1
 [@ipld/dag-cbor]: https://github.com/ipld/js-dag-cbor/


### PR DESCRIPTION
[It turns out] that the [canonical CBOR map key order in RFC 7049] and the [CBOR core deterministic encodings map key order of RFC 8949] are equal *as long* as the map keys are restricted to string only. This is the case in DAG-CBOR. Hence the note about the canonical order of RFC 7049 can be removed.

The requirement for string keys was changed to "must" in the Format section of this spec, as it is also a must in the "Map Keys" section.

[It turns out]: https://github.com/darobin/dasl.ing/issues/26#issuecomment-2967315011
[canonical CBOR map key order in RFC 7049]: https://datatracker.ietf.org/doc/html/rfc7049#section-3.9
[CBOR core deterministic encodings map key order of RFC 8949]: https://datatracker.ietf.org/doc/html/rfc8949#section-4.2.1

---

I've tried my best wording this in an understandable way, but if anyone has better ideas, please comment.