### PR TITLE
Update information on Rust and Python libraries

### DIFF
--- a/libraries/python/index.md
+++ b/libraries/python/index.md
@@ -21,4 +21,4 @@ The [dag-cbrrr](https://github.com/DavidBuchanan314/dag-cbrrr) library provides 
 The [ipld-dag-pb](https://github.com/storacha/py-ipld-dag-pb) library is an implementation of the dag-pb spec. It passes all tests with [DAG-PB fixtures](https://github.com/ipld/codec-fixtures/tree/master/fixtures). It also is compatible with the Hashberg's [`multiformats.CID`](https://github.com/hashberg-io/multiformats/#id9).
 
 ### python-libipld ([PyPI](https://pypi.org/project/libipld/))
-[python-libipld](https://github.com/MarshalX/python-libipld) provides Python bindings to [libipld](https://github.com/ipld/libipld), featuring DAG-CBOR, CID, and CAR decoding, and multibase encode and decode.
+The [python-libipld](https://github.com/MarshalX/python-libipld) library provides performance-oriented implementations for DAG-CBOR, CID, and CAR decoding, and multibase encode and decode. It's implemented in Rust.

--- a/libraries/rust/index.md
+++ b/libraries/rust/index.md
@@ -6,30 +6,23 @@ navTitle: "Rust"
 Rust IPLD Libraries
 ===================
 
-Stand-alone
------------
+### ipld-core
 
-### libipld
+[ipld-core](https://crates.io/crates/ipld-core) provides core types for working with the IPLD Data Model. It also provides macros to produce those types in a JSON-like way.
 
-The currently most feature rich stand-alone IPLD implementation in Rust is [libipld](https://github.com/ipfs-rust/libipld).
+### serde_ipld_dagcbor
 
-It has the [Data Model](/glossary/#data-model) at its core, but it can also directly serialize/deserialize from Rust data types into codecs like DAG-CBOR.
+[serde_ipld_dagcbor](https://crates.io/crates/serde_ipld_dagcbor) is a Serde based implementation for DAG-CBOR encoding and decoding.
 
+### serde_ipld_dagjson
 
-### Datalove IPLD
+[serde_ipld_dagjson](https://crates.io/crates/serde_ipld_dagjson) is a Serde based implementation for DAG-JSON encoding and decoding.
 
-[Datalove IPLD](https://github.com/datalove-app/ipld) is an experimental implementation of IPLD focusing on Schemas.
+### ipld-dagpb
 
-
-
-Integrated into other projects
-------------------------------
-
-### rust-ipfs
-
-rust-ipfs, one of the Rust IPFS implementations, has an [integrated IPLD implementation](https://github.com/rs-ipfs/rust-ipfs/tree/master/src/ipld). That code is based on an early fork of libipld.
+[ipld-dagpb](https://crates.io/crates/ipld-dagpb) is an implementation of DAG-PB.
 
 
-### Forest
+### Selectors
 
-Forest, a Filecoin implementation in Rust, has an [integrated IPLD implementation](https://github.com/ChainSafe/forest/tree/main/ipld) implementation tailored for their needs.
+[Forest](https://forest.chainsafe.io/) has an implementation for selectors [as part of their codebase](https://github.com/ChainSafe/forest/tree/main/src/ipld/selector).


### PR DESCRIPTION
Rust `libipld` is deprecated and replaced by a set of individual crates. Those are now widele used within the IPLD Rust ecosystem.

dataslove-apps' implementation was removed as it hasn't seen any development in years.

The python-libipld implementation isn't using Rust libipld anymore.