### PR TITLE
Fix Accessibility Violations - Add Alt Text to Images and Unique Navi…

### DIFF
--- a/.site/_layouts/main.njk
+++ b/.site/_layouts/main.njk
@@ -31,7 +31,7 @@
 	</header>
 
 	<aside id=sidebar>
-		<nav>
+		<nav aria-label="Main navigation">
 			{% macro renderNavListItem(entry) -%}
 			{%- if entry.key %}
 			<li{% if entry.url == page.url %} class="active-page"{% endif %}>

--- a/index.njk
+++ b/index.njk
@@ -43,10 +43,10 @@ layout:
   <div class="db dt-ns mw8 w-100 center">
     <div class="db dtc-ns v-mid tc tl-ns pv3">
       <a class="dib pl3 pl5-l" href="./" title="Home">
-        <img style="height:81px; width:135px;" src="./img/ipld.svg" />
+        <img style="height:81px; width:135px;" src="./img/ipld.svg" alt="IPLD Logo" />
       </a>
     </div>
-    <nav class="db dtc-ns v-mid tc tr-ns mt2 mt0-ns pb3 pb0-ns nowrap">
+    <nav aria-label="Main" class="db dtc-ns v-mid tc tr-ns mt2 mt0-ns pb3 pb0-ns nowrap">
       <a href="./docs" class="b--transparent ipld-gray hover-blue db dib-ns bb-ns pv3 pv2-ns mh3 f5 fw6 ttu link">Documentation</a>
       <a target="_blank" href="https://github.com/ipld/ipld" class="db dib-ns bb b--transparent pv2 mh3 f5 fw6 ttu link ipld-gray hover-blue">Github</a>
     </nav>
@@ -228,12 +228,12 @@ layout:
     <div class="db dtc-l v-mid tl w-100 w-40-l pv3 ph2">
       <p class="f6">IPLD was started and is sponsored by</p>
       <a class="dib pt2 no-underline" href="https://protocol.ai/">
-        <img src="./img/protocollabs.svg" style="height:48px; vertical-align:middle" class="grow">
+        <img src="./img/protocollabs.svg" style="height:48px; vertical-align:middle" class="grow" alt="Protocol Labs logo">
         <span class="ml2 f4 b white ">Protocol Labs</span>
       </a>
     </div>
     <div class="db dtc-l v-mid w-100 tl tr-l mt2 mt0-l ph2">
-      <nav>
+      <nav aria-label="Footer">
         <a href="./docs" class="b--transparent white hover-blue bb-ns db dib-ns pv2 mr3-ns f5 fw6 ttu link">Documentation</a>
         <a href="https://github.com/ipld/ipld" class="db dib-ns pv2 mr3-ns f5 fw6 ttu link white hover-blue">Github</a>
       </nav>


### PR DESCRIPTION
## Summary
This PR fixes 4 accessibility violations on [website homepage](https://ipld.io/) identified by the [IBM Equal Access Accessibility Checker](https://github.com/IBMa/equal-access):

- Missing alt text on the IPLD logo in the header
- Missing alt text on the Protocol Labs logo in the footer
- Non-unique labels for multiple navigation elements in the header
- Non-unique labels for multiple navigation elements in the footer
<img width="2560" height="1032" alt="image" src="https://github.com/user-attachments/assets/f047605e-68da-4eba-865b-8da07e2f261c" />


## Problems Identified

<img width="1406" height="446" alt="image" src="https://github.com/user-attachments/assets/e8e506f9-bbb9-48de-aeee-a8288bd718df" />
<img width="1406" height="313" alt="image" src="https://github.com/user-attachments/assets/bf7cfef4-3129-411a-b0bc-c021bca581e5" />

### Issue 1: Header IPLD Logo Missing Alt Text

Violation: `img_alt_valid` - The image has neither an accessible name nor is marked as decorative or redundant
Element: `<img src="./img/ipld.svg">` in the header
Location: `/html[1]/body[1]/header[1]/div[1]/div[1]/a[1]/img[1]`
Impact: Screen reader users cannot identify the IPLD logo or understand that clicking it navigates to the homepage

### Issue 2: Non-Unique Navigation Label in Header

Violation: `aria_navigation_label_unique` - Multiple elements with "navigation" role do not have unique labels
Element: `<nav>` in the header
Location: `/html[1]/body[1]/header[1]/div[1]/nav[1]`
Impact: Screen reader users cannot distinguish between multiple navigation regions on the page

### Issue 3: Footer Protocol Labs Logo Missing Alt Text

Violation: `img_alt_valid` - The image has neither an accessible name nor is marked as decorative or redundant
Element: `<img src="./img/protocollabs.svg">` in the footer
Location: `/html[1]/body[1]/footer[1]/div[1]/div[1]/a[1]/img[1]`
Impact: Screen reader users cannot identify the Protocol Labs logo or understand the link's destination

### Issue 4: Non-Unique Navigation Label in Footer

Violation: `aria_navigation_label_unique` - Multiple elements with "navigation" role do not have unique labels
Element: `<nav>` in the footer
Location: `/html[1]/body[1]/footer[1]/div[1]/div[2]/nav[1]`
Impact: Screen reader users cannot distinguish between multiple navigation regions on the page

## Root Causes
### Images Without Alt Text
Both logo images lack the `alt` attribute, which is required for images that convey meaning or are part of interactive elements (links). Without alt text, assistive technologies cannot convey the image's purpose to users.
### Non-Unique Navigation Labels
The page contains multiple `<nav>` elements (in header, footer, and sidebar), but they lack distinguishing `aria-label` attributes. When screen reader users list all navigation landmarks, they see multiple items with the same generic "navigation" label, making it impossible to distinguish which navigation section they want to access.

## Solutions
### Fix 1 & 3: Add Descriptive Alt Text to Images
Added meaningful alt attributes to both logo images:

- IPLD Logo: alt="IPLD Logo" - Identifies the image as the IPLD logo
- Protocol Labs Logo: alt="Protocol Labs logo" - Identifies the image as the Protocol Labs logo

### Fix 2 & 4: Add Unique Labels to Navigation Regions
Added unique aria-label attributes to distinguish navigation regions:

- Header Navigation: aria-label="Main" - Primary site navigation
- Sidebar Navigation: aria-label="Main navigation" - Documentation navigation
Footer Navigation: aria-label="Footer" - Footer-specific navigation

## Additional Info
The patch submitted in this PR was generated by [A11YRepair](https://sites.google.com/view/a11yrepair/home), an automated Web Accessibility repair tool that I developed to address common accessibility violations in web applications. The generated fixes were manually reviewed and validated before submission.

**Fix Before:**
<img width="732" height="102" alt="image" src="https://github.com/user-attachments/assets/8619894a-439f-41d3-be4f-997700ebf2de" />

**Fix After:**
<img width="721" height="102" alt="image" src="https://github.com/user-attachments/assets/507a3125-74b4-4743-a5f5-0201b796d52d" />

**4 violations have been resolved.**