### PR TITLE
fix dag-pb spec link

### DIFF
--- a/specs/codecs/dag-pb/index.md
+++ b/specs/codecs/dag-pb/index.md
@@ -6,5 +6,5 @@ navTitle: "DAG-PB"
 DAG-PB
 ======
 
-- [DAG-PB Specification](./spec/)
+- [DAG-PB Specification](./spec.md)
 - [DAG-PB Fixtures](./fixtures/)


### PR DESCRIPTION
Update link to point to the `.md` file, currently this just 404s.